### PR TITLE
Fix undefined behaviour in matrixMultiply()

### DIFF
--- a/SonicCDDecomp/Scene3D.cpp
+++ b/SonicCDDecomp/Scene3D.cpp
@@ -49,9 +49,9 @@ void matrixMultiply(Matrix *matrixA, Matrix *matrixB)
 
     for (int i = 0; i < 0x10; ++i) {
         uint RowB = i & 3;
-        uint RowA = i & 0xC;
-        output[i] = (matrixA->values[0][RowA + 3] * matrixB->values[3][RowB] >> 8) + (matrixA->values[0][RowA + 2] * matrixB->values[2][RowB] >> 8)
-                    + (matrixA->values[0][RowA + 1] * matrixB->values[1][RowB] >> 8) + (matrixA->values[0][RowA] * matrixB->values[0][RowB] >> 8);
+        uint RowA = (i & 0xC)/4;
+        output[i] = (matrixA->values[RowA][3] * matrixB->values[3][RowB] >> 8) + (matrixA->values[RowA][2] * matrixB->values[2][RowB] >> 8)
+                    + (matrixA->values[RowA][1] * matrixB->values[1][RowB] >> 8) + (matrixA->values[RowA][0] * matrixB->values[0][RowB] >> 8);
     }
 
     for (int i = 0; i < 0x10; ++i) matrixA->values[i / 4][i % 4] = output[i];


### PR DESCRIPTION
Compiling the project with `gcc -O3` (full optimizations) results in the following:
![0260f47d5830](https://user-images.githubusercontent.com/6003656/103714541-8c8bf200-4fc7-11eb-968d-a975bcc9e72c.png)

Using the Undefined Behaviour Sanitizer, we can see messages such as the following:
```
SonicCDDecomp/Scene3D.cpp:53:49: runtime error: index 7 out of bounds for type 'int [4]'
SonicCDDecomp/Scene3D.cpp:53:114: runtime error: index 6 out of bounds for type 'int [4]'
SonicCDDecomp/Scene3D.cpp:54:51: runtime error: index 5 out of bounds for type 'int [4]'
SonicCDDecomp/Scene3D.cpp:54:112: runtime error: index 4 out of bounds for type 'int [4]'
```

This happens because the code treats `int values[4][4]` as a 1d array by accessing values[0] past index 3, thus causing the undefined behaviour which results in gcc producing incorrect results.

Given some example matrices
```C
    Matrix m1 = {
        {
            {256, 0, 0, 0},
            {0, 256, 0, 0},
            {0, 0, 256, 0},
            {0, 0, 20041, 256},
        },
    };
    
    Matrix m2 = {
        {
            {-132, -220, 0, 0},
            {220, -132, 0, 0},
            {0, 0, 256, 0},
            {0, 0, 0, 256},
        },
    };
```

the expected result is
```
-132 -220 0 0 
220 -132 0 0 
0 0 256 0 
0 0 20041 256 
```
but gcc with full optimizations produces
```
-132 -220 0 0 
0 0 0 0 
0 0 0 0 
0 0 0 0 
```

This PR fixes this issue by accessing the arrays correctly, eliminating UB.