### PR TITLE
Add Linux Makefile and fix a couple of bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,34 @@
-CXXFLAGS = -Og -ggdb3 -fsanitize=address
-
-CXXFLAGS_ALL = $(shell pkg-config --cflags sdl2 theoraplay vorbisfile) $(CXXFLAGS)
+CXXFLAGS_ALL = $(shell pkg-config --cflags sdl2 vorbisfile vorbis theoradec) -Idependencies/all/theoraplay $(CXXFLAGS)
 LDFLAGS_ALL = $(LDFLAGS)
-LIBS_ALL = $(shell pkg-config --libs sdl2 theoraplay vorbisfile) $(LIBS)
+LIBS_ALL = $(shell pkg-config --libs sdl2 vorbisfile vorbis theoradec) $(LIBS)
 
-OBJECTS = Animation.cpp \
-          Audio.cpp \
-          Collision.cpp \
-          Debug.cpp \
-          Drawing.cpp \
-          Ini.cpp \
-          Input.cpp \
-          main.cpp \
-          Math.cpp \
-          Object.cpp \
-          Palette.cpp \
-          Player.cpp \
-          Reader.cpp \
-          RetroEngine.cpp \
-          Scene.cpp \
-          Scene3D.cpp \
-          Script.cpp \
-          Sprite.cpp \
-          String.cpp \
-          Text.cpp \
-          Userdata.cpp \
-          Video.cpp
+SOURCES = dependencies/all/theoraplay/theoraplay.c \
+          SonicCDDecomp/Animation.cpp \
+          SonicCDDecomp/Audio.cpp \
+          SonicCDDecomp/Collision.cpp \
+          SonicCDDecomp/Debug.cpp \
+          SonicCDDecomp/Drawing.cpp \
+          SonicCDDecomp/Ini.cpp \
+          SonicCDDecomp/Input.cpp \
+          SonicCDDecomp/main.cpp \
+          SonicCDDecomp/Math.cpp \
+          SonicCDDecomp/Object.cpp \
+          SonicCDDecomp/Palette.cpp \
+          SonicCDDecomp/Player.cpp \
+          SonicCDDecomp/Reader.cpp \
+          SonicCDDecomp/RetroEngine.cpp \
+          SonicCDDecomp/Scene.cpp \
+          SonicCDDecomp/Scene3D.cpp \
+          SonicCDDecomp/Script.cpp \
+          SonicCDDecomp/Sprite.cpp \
+          SonicCDDecomp/String.cpp \
+          SonicCDDecomp/Text.cpp \
+          SonicCDDecomp/Userdata.cpp \
+          SonicCDDecomp/Video.cpp
 
-objects/%.o: SonicCDDecomp/%
+objects/%.o: %
 	mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS_ALL) $^ -o $@ -c
 
-soniccd: $(OBJECTS:%=objects/%.o)
+soniccd: $(SOURCES:%=objects/%.o)
 	$(CXX) $(CXXFLAGS_ALL) $(LDFLAGS_ALL) $^ -o $@ $(LIBS_ALL)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+CXXFLAGS = -Og -ggdb3 -fsanitize=address
+
+CXXFLAGS_ALL = $(shell pkg-config --cflags sdl2 theoraplay vorbisfile) $(CXXFLAGS)
+LDFLAGS_ALL = $(LDFLAGS)
+LIBS_ALL = $(shell pkg-config --libs sdl2 theoraplay vorbisfile) $(LIBS)
+
+OBJECTS = Animation.cpp \
+          Audio.cpp \
+          Collision.cpp \
+          Debug.cpp \
+          Drawing.cpp \
+          Ini.cpp \
+          Input.cpp \
+          main.cpp \
+          Math.cpp \
+          Object.cpp \
+          Palette.cpp \
+          Player.cpp \
+          Reader.cpp \
+          RetroEngine.cpp \
+          Scene.cpp \
+          Scene3D.cpp \
+          Script.cpp \
+          Sprite.cpp \
+          String.cpp \
+          Text.cpp \
+          Userdata.cpp \
+          Video.cpp
+
+objects/%.o: SonicCDDecomp/%
+	mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS_ALL) $^ -o $@ -c
+
+soniccd: $(OBJECTS:%=objects/%.o)
+	$(CXX) $(CXXFLAGS_ALL) $(LDFLAGS_ALL) $^ -o $@ $(LIBS_ALL)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ even if your platform isn't supported by the official releases, buy it for the a
 * Clone the repo, then follow the instructions in the [depencencies readme for mac](./dependencies/mac/dependencies.txt) to setup dependencies, then build via the xcode project
 * or grab a prebuilt executable from the releases section
 
+## Linux:
+* Clone the repo, install your distro's SDL2, libtheora, and libvorbisfile packages, and then run `make` in the cloned repo's directory
+
 ## iOS:
 * Clone the repo, then follow the instructions in the [depencencies readme for iOS](./dependencies/ios/dependencies.txt) to setup dependencies, then build via the xcode project
 

--- a/SonicCDDecomp/Audio.hpp
+++ b/SonicCDDecomp/Audio.hpp
@@ -87,6 +87,8 @@ void ProcessAudioMixing(void *sfx, Uint8 *dst, const byte *src, SDL_AudioFormat 
 inline void freeMusInfo()
 {
     if (musInfo.loaded) {
+        SDL_LockAudio();
+
         if (musInfo.buffer)
             delete[] musInfo.buffer;
         if (musInfo.extraBuffer)
@@ -100,6 +102,8 @@ inline void freeMusInfo()
         musInfo.audioLen     = 0;
         musInfo.currentTrack = nullptr;
         musInfo.loaded       = false;
+
+        SDL_UnlockAudio();
     }
 }
 #else

--- a/SonicCDDecomp/RetroEngine.cpp
+++ b/SonicCDDecomp/RetroEngine.cpp
@@ -222,50 +222,51 @@ void RetroEngine::Run()
         frameStart = SDL_GetTicks();
         frameDelta = frameStart - frameEnd;
 
-        if (frameDelta > 1000.0f / (float)refreshRate) {
-            frameEnd = frameStart;
-            
-            running = processEvents();
+        if (frameDelta < 1000.0f / (float)refreshRate)
+            SDL_Delay(1000.0f / (float)refreshRate - frameDelta);
 
-            for (int s = 0; s < gameSpeed; ++s) {
-                ProcessInput();
+        frameEnd = SDL_GetTicks();
 
-                if (!masterPaused || frameStep) {
-                    switch (gameMode) {
-                        case ENGINE_DEVMENU: processStageSelect(); break;
-                        case ENGINE_MAINGAME: ProcessStage(); break;
-                        case ENGINE_INITDEVMENU:
-                            LoadGameConfig("Data/Game/GameConfig.bin");
-                            initDevMenu();
-                            ResetCurrentStageFolder();
-                            break;
-                        case ENGINE_EXITGAME: running = false; break;
-                        case ENGINE_SCRIPTERROR:
-                            LoadGameConfig("Data/Game/GameConfig.bin");
-                            initErrorMessage();
-                            ResetCurrentStageFolder();
-                            break;
-                        case ENGINE_ENTER_HIRESMODE:
-                            gameMode    = ENGINE_MAINGAME;
-                            highResMode = true;
-                            break;
-                        case ENGINE_EXIT_HIRESMODE:
-                            gameMode    = ENGINE_MAINGAME;
-                            highResMode = false;
-                            break;
-                        case ENGINE_PAUSE: break;
-                        case ENGINE_WAIT: break;
-                        case ENGINE_VIDEOWAIT:
-                            if (ProcessVideo() == 1)
-                                gameMode = ENGINE_MAINGAME;
-                            break;
-                        default: break;
-                    }
+        running = processEvents();
 
-                    RenderRenderDevice();
+        for (int s = 0; s < gameSpeed; ++s) {
+            ProcessInput();
 
-                    frameStep = false;
+            if (!masterPaused || frameStep) {
+                switch (gameMode) {
+                    case ENGINE_DEVMENU: processStageSelect(); break;
+                    case ENGINE_MAINGAME: ProcessStage(); break;
+                    case ENGINE_INITDEVMENU:
+                        LoadGameConfig("Data/Game/GameConfig.bin");
+                        initDevMenu();
+                        ResetCurrentStageFolder();
+                        break;
+                    case ENGINE_EXITGAME: running = false; break;
+                    case ENGINE_SCRIPTERROR:
+                        LoadGameConfig("Data/Game/GameConfig.bin");
+                        initErrorMessage();
+                        ResetCurrentStageFolder();
+                        break;
+                    case ENGINE_ENTER_HIRESMODE:
+                        gameMode    = ENGINE_MAINGAME;
+                        highResMode = true;
+                        break;
+                    case ENGINE_EXIT_HIRESMODE:
+                        gameMode    = ENGINE_MAINGAME;
+                        highResMode = false;
+                        break;
+                    case ENGINE_PAUSE: break;
+                    case ENGINE_WAIT: break;
+                    case ENGINE_VIDEOWAIT:
+                        if (ProcessVideo() == 1)
+                            gameMode = ENGINE_MAINGAME;
+                        break;
+                    default: break;
                 }
+
+                RenderRenderDevice();
+
+                frameStep = false;
             }
         }
     }


### PR DESCRIPTION
There'll probably need to be more work put into locking the audio device when modifying variables that are later read by SDL2's audio callback. I'm having trouble making heads or tails of the audio system, so I've only modified the one function that was causing invalid memory accesses during testing.

The `SDL_Delay` thing is to stop the game using 100% of a CPU core all the time: rather than waste cycles in an idle-loop, `SDL_Delay` yields to other processes and then returns after the specified number of milliseconds.