### PR TITLE
Add support for video sound (and fix garbage in fullscreen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,6 @@ Currently only windows & mac are supported by this decompilation, however the ba
 if you've cloned this repo and ported it to a platform not on the list or made some changes you'd like to see added to this repo, submit a pull request and it'll most likely be added
 
 # FAQ
-### Q: Sound doesn't play when videos are playing!
-### A: Currently the video playback system doesn't support streaming audio from .ogv files, the workaround is to open the ogv file in any kind of video/audio software that supports it and save just the audio as an ogg vorbis file called [videoName]\[JP/US].ogg in the same directory as the .ogv
-
 ### Q: Why dont some buttons in the menu work?
 ### A: Buttons like leaderboards & achievements require code to be added to support online functionality & menus (though they are saved anyways), and other buttons like the controls button on PC or privacy button on mobile have no game code and are instead hardcoded through callbacks, and I just didnt feel like going through the effort to decompile all that, since its not really worth it
 

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -22,6 +22,7 @@ MusicPlaybackInfo musInfo;
 
 #if RETRO_USING_SDL
 SDL_AudioSpec audioDeviceFormat;
+SDL_AudioStream *ogv_stream;
 
 #define AUDIO_FREQUENCY (44100)
 #define AUDIO_FORMAT    (0x8010) /**< Signed 16-bit samples */
@@ -53,6 +54,20 @@ int InitAudioPlayback()
         printLog("Unable to open audio device: %s", SDL_GetError());
         return false;
     }
+
+    // Init video sound stuff
+    // TODO: Unfortunately, we're assuming that video sound is stereo at 48000Hz.
+    // This is true of every .ogv file in the game (the Steam version, at least),
+    // but it would be nice to make this dynamic. Unfortunately, THEORAPLAY's API
+    // makes this awkward.
+    ogv_stream = SDL_NewAudioStream(AUDIO_F32, 2, 48000, audioDeviceFormat.format,
+                                  audioDeviceFormat.channels, audioDeviceFormat.freq);
+    if (!ogv_stream) {
+        printLog("Failed to create stream: %s", SDL_GetError());
+        SDL_CloseAudio();
+        return false;
+    }
+
     #endif
 
     FileInfo info;
@@ -221,6 +236,30 @@ void ProcessAudioPlayback(void *data, Uint8 *stream, int len)
         return;
 
     ProcessMusicStream(data, stream, len);
+
+    // Process music being played by a video
+    if (videoPlaying) {
+        // TODO - Lock the audio device when THEORAPLAY is accessing the audio list(?)
+
+        // Fetch THEORAPLAY audio packets, and shove them into the SDL Audio Stream
+        const THEORAPLAY_AudioPacket *packet;
+
+        while ((packet = THEORAPLAY_getAudio(videoDecoder)) != NULL) {
+            SDL_AudioStreamPut(ogv_stream, packet->samples, packet->frames * sizeof (float) * 2); // 2 for stereo
+            THEORAPLAY_freeAudio(packet);
+        }
+
+        byte buffer[AUDIO_BUFFERSIZE];
+
+        // Fetch the converted audio data, which is ready for mixing.
+        // TODO: This code doesn't account for `len` being larger than the buffer.
+        // ...But neither does `trackRequestMoreData`, so I guess it's not my problem.
+        int get = SDL_AudioStreamGet(ogv_stream, buffer, len);
+
+        // Mix the converted audio data into the final output
+        if (get != -1)
+            ProcessAudioMixing(NULL, stream, buffer, audioDeviceFormat.format, get, (bgmVolume * masterVolume) / MAX_VOLUME, true); // TODO - Should we be using the music volume?
+    }
 
     for (byte i = 0; i < CHANNEL_COUNT; ++i) {
         ChannelInfo *sfx = &sfxChannels[i];

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -252,8 +252,8 @@ void ProcessAudioPlayback(void *data, Uint8 *stream, int len)
         byte buffer[AUDIO_BUFFERSIZE];
 
         // If we need more samples, assume we've reached the end of the file,
-        // and flush the audio stream. If we were wrong, and there's still more
-        // file left, then there will be a gap in the audio. Sorry.
+        // and flush the audio stream so we can get more. If we were wrong, and
+        // there's still more file left, then there will be a gap in the audio. Sorry.
         if (SDL_AudioStreamAvailable(ogv_stream) < len)
             SDL_AudioStreamFlush(ogv_stream);
 

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -239,7 +239,6 @@ void ProcessAudioPlayback(void *data, Uint8 *stream, int len)
 
     // Process music being played by a video
     if (videoPlaying) {
-        // TODO - Lock the audio device when THEORAPLAY is accessing the audio list(?)
         // TODO - Aren't the ending videos meant to play different music when the US soundtrack is enabled?
 
         // Fetch THEORAPLAY audio packets, and shove them into the SDL Audio Stream

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -240,6 +240,7 @@ void ProcessAudioPlayback(void *data, Uint8 *stream, int len)
     // Process music being played by a video
     if (videoPlaying) {
         // TODO - Lock the audio device when THEORAPLAY is accessing the audio list(?)
+        // TODO - Aren't the ending videos meant to play different music when the US soundtrack is enabled?
 
         // Fetch THEORAPLAY audio packets, and shove them into the SDL Audio Stream
         const THEORAPLAY_AudioPacket *packet;

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -252,6 +252,12 @@ void ProcessAudioPlayback(void *data, Uint8 *stream, int len)
 
         byte buffer[AUDIO_BUFFERSIZE];
 
+        // If we need more samples, assume we've reached the end of the file,
+        // and flush the audio stream. If we were wrong, and there's still more
+        // file left, then there will be a gap in the audio. Sorry.
+        if (SDL_AudioStreamAvailable(ogv_stream) < len)
+            SDL_AudioStreamFlush(ogv_stream);
+
         // Fetch the converted audio data, which is ready for mixing.
         // TODO: This code doesn't account for `len` being larger than the buffer.
         // ...But neither does `trackRequestMoreData`, so I guess it's not my problem.
@@ -260,6 +266,9 @@ void ProcessAudioPlayback(void *data, Uint8 *stream, int len)
         // Mix the converted audio data into the final output
         if (get != -1)
             ProcessAudioMixing(NULL, stream, buffer, audioDeviceFormat.format, get, (bgmVolume * masterVolume) / MAX_VOLUME, true); // TODO - Should we be using the music volume?
+    }
+    else {
+        SDL_AudioStreamClear(ogv_stream);   // Prevent leftover audio from playing at the start of the next video
     }
 
     for (byte i = 0; i < CHANNEL_COUNT; ++i) {

--- a/SonicCDDecomp/Drawing.cpp
+++ b/SonicCDDecomp/Drawing.cpp
@@ -115,6 +115,11 @@ void RenderRenderDevice()
 
     int pitch = 0;
     SDL_SetRenderTarget(Engine.renderer, NULL);
+
+    // Clear the screen. This is needed to keep the
+    // pillarboxes in fullscreen from displaying garbage data.
+    SDL_RenderClear(Engine.renderer);
+
     ushort *pixels = NULL;
     if (Engine.gameMode != ENGINE_VIDEOWAIT) {
         if (!drawStageGFXHQ) {

--- a/SonicCDDecomp/Video.cpp
+++ b/SonicCDDecomp/Video.cpp
@@ -7,7 +7,6 @@ int videoHeight       = 0;
 
 THEORAPLAY_Decoder *videoDecoder;
 const THEORAPLAY_VideoFrame *videoVidData;
-const THEORAPLAY_AudioPacket *videoAudioData;
 THEORAPLAY_Io callbacks;
 
 byte videoData = 0;
@@ -53,14 +52,12 @@ void PlayVideoFile(char *filePath) {
             printLog("Video Decoder Error!");
             return;
         }
-        while (!videoAudioData || !videoVidData) {
-            if (!videoAudioData)
-                videoAudioData = THEORAPLAY_getAudio(videoDecoder);
+        while (!videoVidData) {
             if (!videoVidData)
                 videoVidData = THEORAPLAY_getVideo(videoDecoder);
         }
-        if (!videoAudioData || !videoVidData) {
-            printLog("Video or Audio Error!");
+        if (!videoVidData) {
+            printLog("Video Error!");
             return;
         }
 
@@ -222,8 +219,6 @@ void StopVideoPlayback()
 
         if (videoVidData)
             THEORAPLAY_freeVideo(videoVidData);
-        if (videoAudioData)
-            THEORAPLAY_freeAudio(videoAudioData);
         if (videoDecoder)
             THEORAPLAY_stopDecode(videoDecoder);
 

--- a/SonicCDDecomp/Video.cpp
+++ b/SonicCDDecomp/Video.cpp
@@ -72,23 +72,6 @@ void PlayVideoFile(char *filePath) {
         videoPlaying = true;
         trackID        = TRACK_COUNT - 1;
 
-        // "temp" but I really cannot be bothered to go through the nightmare that is streaming the audio data
-        // (yes I tried, and probably cut years off my life)
-        StrCopy(filepath, "videos/");
-        StrAdd(filepath, filePath);
-        if (StrComp(filePath, "Good_Ending") || StrComp(filePath, "Bad_Ending") || StrComp(filePath, "Opening")) {
-            if (!GetGlobalVariableByName("Options.Soundtrack"))
-                StrAdd(filepath, "JP");
-            else
-                StrAdd(filepath, "US");
-        }
-        StrAdd(filepath, ".ogg");
-
-        TrackInfo *track = &musicTracks[trackID];
-        StrCopy(track->fileName, filepath);
-        track->trackLoop = false;
-        track->loopPoint = 0;
-
         //Switch it off so the reader can access it
         bool df              = Engine.usingDataFile;
         Engine.usingDataFile = false;

--- a/SonicCDDecomp/Video.cpp
+++ b/SonicCDDecomp/Video.cpp
@@ -64,9 +64,6 @@ void PlayVideoFile(char *filePath) {
             return;
         }
 
-        //clear audio data, we dont use it
-        while ((videoAudioData = THEORAPLAY_getAudio(videoDecoder)) != NULL) THEORAPLAY_freeAudio(videoAudioData);
-
         videoWidth  = videoVidData->width;
         videoHeight = videoVidData->height;
         SetupVideoBuffer(videoWidth, videoHeight);
@@ -226,9 +223,6 @@ int ProcessVideo()
                 THEORAPLAY_freeVideo(videoVidData);
                 videoVidData = NULL;
             }
-
-            //Clear audio data
-            while ((videoAudioData = THEORAPLAY_getAudio(videoDecoder)) != NULL) THEORAPLAY_freeAudio(videoAudioData);
 
             return 2; // its playing as expected
         }

--- a/SonicCDDecomp/Video.cpp
+++ b/SonicCDDecomp/Video.cpp
@@ -218,9 +218,15 @@ void StopVideoPlayback()
             fadeMode = 0;
 
         if (videoVidData)
+        {
             THEORAPLAY_freeVideo(videoVidData);
+            videoVidData = NULL;
+        }
         if (videoDecoder)
+        {
             THEORAPLAY_stopDecode(videoDecoder);
+            videoDecoder = NULL;
+        }
 
         CloseVideoBuffer();
         videoPlaying = false;

--- a/SonicCDDecomp/Video.cpp
+++ b/SonicCDDecomp/Video.cpp
@@ -214,22 +214,27 @@ int ProcessVideo()
 void StopVideoPlayback()
 {
     if (videoPlaying) {
+        // `videoPlaying` and `videoDecoder` are read by
+        // the audio thread, so lock it to prevent a race
+        // condition that results in invalid memory accesses.
+        SDL_LockAudio();
+
         if (videoSkipped && fadeMode >= 0xFF)
             fadeMode = 0;
 
-        if (videoVidData)
-        {
+        if (videoVidData) {
             THEORAPLAY_freeVideo(videoVidData);
             videoVidData = NULL;
         }
-        if (videoDecoder)
-        {
+        if (videoDecoder) {
             THEORAPLAY_stopDecode(videoDecoder);
             videoDecoder = NULL;
         }
 
         CloseVideoBuffer();
         videoPlaying = false;
+
+        SDL_UnlockAudio();
     }
 }
 


### PR DESCRIPTION
I'm still having trouble understanding the audio system, so this might not be implemented ideally.

Right now, there is the issue of the US soundtrack option not affecting the videos (JP music just plays instead), but I'm not sure what I can do about it. My guess is that the video contains multiple audio streams, and theoraplay is hardcoded to only play the first one. I'll try looking into it, and I'll update this message if I find anything.

Adding this may have introduced some race-conditions. I've fixed as many as I could find, but if you encounter any strange crashes relating to audio and/or videos, I can look into it. Your comment wasn't wrong: this stuff is a headache.

I've also added an `SDL_RenderClear` call to the renderer, so that the pillarboxes that appear in fullscreen won't display garbage.