### PR TITLE
Support US soundtrack video music

### DIFF
--- a/SonicCDDecomp/Video.cpp
+++ b/SonicCDDecomp/Video.cpp
@@ -46,7 +46,7 @@ void PlayVideoFile(char *filePath) {
         callbacks.read     = videoRead;
         callbacks.close    = videoClose;
         callbacks.userdata = (void *)file;
-        videoDecoder       = THEORAPLAY_startDecode(&callbacks, /*FPS*/ 30, THEORAPLAY_VIDFMT_RGBA);
+        videoDecoder       = THEORAPLAY_startDecode(&callbacks, /*FPS*/ 30, THEORAPLAY_VIDFMT_RGBA, GetGlobalVariableByName("Options.Soundtrack") ? 1 : 0);
 
         if (!videoDecoder) {
             printLog("Video Decoder Error!");

--- a/dependencies/all/theoraplay/theoraplay.c
+++ b/dependencies/all/theoraplay/theoraplay.c
@@ -297,6 +297,7 @@ static void WorkerThread(TheoraDecoder *ctx)
                     // Reset the vorbis state stuff, and wait for the next one.
                     vorbis_info_init(&vinfo);
                     vorbis_comment_init(&vcomment);
+                    ogg_stream_clear(&test);
                 }
             } // else if
             else

--- a/dependencies/all/theoraplay/theoraplay.h
+++ b/dependencies/all/theoraplay/theoraplay.h
@@ -55,10 +55,12 @@ typedef struct THEORAPLAY_AudioPacket
 
 THEORAPLAY_Decoder *THEORAPLAY_startDecodeFile(const char *fname,
                                                const unsigned int maxframes,
-                                               THEORAPLAY_VideoFormat vidfmt);
+                                               THEORAPLAY_VideoFormat vidfmt,
+                                               unsigned int audio_bitstream);
 THEORAPLAY_Decoder *THEORAPLAY_startDecode(THEORAPLAY_Io *io,
                                            const unsigned int maxframes,
-                                           THEORAPLAY_VideoFormat vidfmt);
+                                           THEORAPLAY_VideoFormat vidfmt,
+                                           unsigned int audio_bitstream);
 void THEORAPLAY_stopDecode(THEORAPLAY_Decoder *decoder);
 
 int THEORAPLAY_isDecoding(THEORAPLAY_Decoder *decoder);


### PR DESCRIPTION
I'm not sure how support for the mobile version's video files is meant to work: the game doesn't seem to indicate the bitstream it wants anywhere explicitly, so I just hardcode it based on the soundtrack option, but that should mean the mobile version's videos - which only have one audio stream - will now be mute when the US soundtrack is enabled.