### PR TITLE
Overhaul audio mixer

### DIFF
--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -246,6 +246,7 @@ void ProcessAudioPlayback(void *userdata, Uint8 *stream, int len)
 
         const size_t samples_to_do = (samples_remaining < MIX_BUFFER_SAMPLES) ? samples_remaining : MIX_BUFFER_SAMPLES;
 
+        // Mix music
         ProcessMusicStream(mix_buffer, samples_to_do);
 
         // Process music being played by a video
@@ -281,6 +282,7 @@ void ProcessAudioPlayback(void *userdata, Uint8 *stream, int len)
             SDL_AudioStreamClear(ogv_stream);   // Prevent leftover audio from playing at the start of the next video
         }
 
+        // Mix SFX
         for (byte i = 0; i < CHANNEL_COUNT; ++i) {
             ChannelInfo *sfx = &sfxChannels[i];
             if (sfx == NULL)
@@ -312,6 +314,7 @@ void ProcessAudioPlayback(void *userdata, Uint8 *stream, int len)
             }
         }
 
+        // Clamp mixed samples back to 16-bit and write them to the output buffer
         for (size_t i = 0; i < sizeof(mix_buffer) / sizeof(*mix_buffer); ++i)
         {
             const Sint16 max_audioval = ((1 << (16 - 1)) - 1);

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -303,7 +303,7 @@ void ProcessAudioPlayback(void *data, Uint8 *stream_uint8, int len)
 }
 
 #if RETRO_USING_SDL
-void ProcessAudioMixing(Sint16 *dst, const Sint16 *src, Uint32 len, int volume, signed char pan)
+void ProcessAudioMixing(Sint16 *dst, const Sint16 *src, int len, int volume, signed char pan)
 {
     if (volume == 0)
         return;

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -205,7 +205,7 @@ void ProcessMusicStream(void *data, Sint16 *stream, int len)
             int bytes        = trackRequestMoreData(AUDIO_SAMPLES, len * 2);
             if (bytes > 0) {
                 int vol = (bgmVolume * masterVolume) / MAX_VOLUME;
-                ProcessAudioMixing(NULL, stream, musInfo.buffer, audioDeviceFormat.format, len, vol, true);
+                ProcessAudioMixing(NULL, stream, musInfo.buffer, len, vol, true);
             }
 
             switch (bytes) {
@@ -264,7 +264,7 @@ void ProcessAudioPlayback(void *data, Uint8 *stream_uint8, int len)
 
         // Mix the converted audio data into the final output
         if (get != -1)
-            ProcessAudioMixing(NULL, stream, buffer, audioDeviceFormat.format, get, (bgmVolume * masterVolume) / MAX_VOLUME, true); // TODO - Should we be using the music volume?
+            ProcessAudioMixing(NULL, stream, buffer, get, (bgmVolume * masterVolume) / MAX_VOLUME, true); // TODO - Should we be using the music volume?
     }
     else {
         SDL_AudioStreamClear(ogv_stream);   // Prevent leftover audio from playing at the start of the next video
@@ -282,7 +282,7 @@ void ProcessAudioPlayback(void *data, Uint8 *stream_uint8, int len)
             if (sfx->sampleLength > 0) {
                 int sampleLen = (len > sfx->sampleLength) ? sfx->sampleLength : len;
 #if RETRO_USING_SDL
-                ProcessAudioMixing(sfx, stream, sfx->samplePtr, audioDeviceFormat.format, sampleLen, sfxVolume, false);
+                ProcessAudioMixing(sfx, stream, sfx->samplePtr, sampleLen, sfxVolume, false);
 #endif
 
                 sfx->samplePtr += sampleLen;
@@ -303,7 +303,7 @@ void ProcessAudioPlayback(void *data, Uint8 *stream_uint8, int len)
 }
 
 #if RETRO_USING_SDL
-void ProcessAudioMixing(void *sfx, Sint16 *dst, const Sint16 *src, SDL_AudioFormat format, Uint32 len, int volume, bool music)
+void ProcessAudioMixing(void *sfx, Sint16 *dst, const Sint16 *src, Uint32 len, int volume, bool music)
 {
     if (volume == 0)
         return;

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -327,36 +327,32 @@ void ProcessAudioMixing(void *sfx, Sint16 *dst, const Sint16 *src, Uint32 len, i
         }
     }
 
-    Sint16 src1, src2;
-    int dst_sample;
-    const int max_audioval = ((1 << (16 - 1)) - 1);
-    const int min_audioval = -(1 << (16 - 1));
+    const Sint16 max_audioval = ((1 << (16 - 1)) - 1);
+    const Sint16 min_audioval = -(1 << (16 - 1));
 
     len /= 2;
     while (len--) {
-        src1 = src[0];
-        ADJUST_VOLUME(src1, volume);
+        long sample = *src++;
+        ADJUST_VOLUME(sample, volume);
 
         if (panL != 0 || panR != 0) {
             if ((i % 2) != 0) {
-                src1 *- panR;
+                sample *- panR;
             }
             else {
-                src1 *- panL;
+                sample *- panL;
             }
         }
 
-        src2 = dst[0];
-        src += 1;
-        dst_sample = src1 + src2;
+        sample += *dst;
 
-        if (dst_sample > max_audioval) {
-            dst_sample = max_audioval;
-        }
-        else if (dst_sample < min_audioval) {
-            dst_sample = min_audioval;
-        }
-        *dst++ = dst_sample;
+        if (sample > max_audioval)
+            *dst++ = max_audioval;
+        else if (sample < min_audioval)
+            *dst++ = min_audioval;
+        else
+            *dst++ = sample;
+
         i++;
     }
 }

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -150,8 +150,7 @@ void ProcessMusicStream(Sint32 *stream, size_t bytes_wanted)
         case MUSIC_READY:
         case MUSIC_PLAYING: {
 #if RETRO_USING_SDL
-            while (SDL_AudioStreamAvailable(musInfo.stream) < bytes_wanted)
-            {
+            while (SDL_AudioStreamAvailable(musInfo.stream) < bytes_wanted) {
                 // We need more samples: get some
                 long bytes_read = ov_read(&musInfo.vorbisFile, (char*)musInfo.buffer, sizeof(musInfo.buffer), 0, 2, 1, &musInfo.vorbBitstream);
 

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -337,10 +337,10 @@ void ProcessAudioMixing(void *sfx, Sint16 *dst, const Sint16 *src, Uint32 len, i
 
         if (panL != 0 || panR != 0) {
             if ((i % 2) != 0) {
-                sample *- panR;
+                sample *= panR;
             }
             else {
-                sample *- panL;
+                sample *= panL;
             }
         }
 

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -285,7 +285,7 @@ void ProcessAudioPlayback(void *data, Uint8 *stream_uint8, int len)
                 ProcessAudioMixing(stream, sfx->samplePtr, sampleLen, sfxVolume, sfx->pan);
 #endif
 
-                sfx->samplePtr += sampleLen;
+                sfx->samplePtr += sampleLen / sizeof(Sint16);
                 sfx->sampleLength -= sampleLen;
             }
 

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -271,8 +271,6 @@ void ProcessAudioPlayback(void *userdata, Uint8 *stream, int len)
                 SDL_AudioStreamFlush(ogv_stream);
 
             // Fetch the converted audio data, which is ready for mixing.
-            // TODO: This code doesn't account for `len` being larger than the buffer.
-            // ...But neither does `trackRequestMoreData`, so I guess it's not my problem.
             int get = SDL_AudioStreamGet(ogv_stream, buffer, bytes_to_do);
 
             // Mix the converted audio data into the final output

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -258,7 +258,7 @@ void ProcessAudioPlayback(void *userdata, Uint8 *stream, int len)
                     sfx->samplePtr += sampleLen;
                     sfx->sampleLength -= sampleLen;
 
-                    if (sfx->sampleLength <= 0) {
+                    if (sfx->sampleLength == 0) {
                         if (sfx->loopSFX) {
                             sfx->samplePtr    = sfxList[sfx->sfxID].buffer;
                             sfx->sampleLength = sfxList[sfx->sfxID].length;

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -196,7 +196,7 @@ int trackRequestMoreData(uint samples, uint amount)
 #endif
 
 
-void ProcessMusicStream(void *data, Sint16 *stream, int len)
+void ProcessMusicStream(Sint32 *stream, size_t len)
 {
     if (!musInfo.loaded)
         return;
@@ -204,10 +204,10 @@ void ProcessMusicStream(void *data, Sint16 *stream, int len)
         case MUSIC_READY:
         case MUSIC_PLAYING: {
 #if RETRO_USING_SDL
-            int bytes        = trackRequestMoreData(AUDIO_SAMPLES, len * 2);
+            int bytes        = trackRequestMoreData(AUDIO_SAMPLES, len * sizeof(Sint16) * 2);
             if (bytes > 0) {
                 int vol = (bgmVolume * masterVolume) / MAX_VOLUME;
-      //          ProcessAudioMixing(stream, musInfo.buffer, len, vol, 0);
+                ProcessAudioMixing(stream, musInfo.buffer, len, vol, 0);
             }
 
             switch (bytes) {
@@ -246,7 +246,7 @@ void ProcessAudioPlayback(void *userdata, Uint8 *stream, int len)
 
         const size_t samples_to_do = (samples_remaining < MIX_BUFFER_SAMPLES) ? samples_remaining : MIX_BUFFER_SAMPLES;
 
-//        ProcessMusicStream(data, stream, len);
+        ProcessMusicStream(mix_buffer, samples_to_do);
 
         // Process music being played by a video
         if (videoPlaying) {

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -65,7 +65,7 @@ int InitAudioPlayback()
                                   audioDeviceFormat.channels, audioDeviceFormat.freq);
     if (!ogv_stream) {
         printLog("Failed to create stream: %s", SDL_GetError());
-        SDL_CloseAudio();
+        SDL_CloseAudioDevice(audioDevice);
         return false;
     }
 

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -294,13 +294,13 @@ void ProcessAudioPlayback(void *userdata, Uint8 *stream, int len)
 
             if (sfx->samplePtr) {
                 if (sfx->sampleLength > 0) {
-                    int sampleLen = ((sfx->sampleLength/sizeof(Sint16)) < samples_to_do) ? (sfx->sampleLength/sizeof(Sint16)) : samples_to_do;
+                    int sampleLen = (sfx->sampleLength < samples_to_do) ? sfx->sampleLength : samples_to_do;
     #if RETRO_USING_SDL
                     ProcessAudioMixing(mix_buffer, sfx->samplePtr, sampleLen, sfxVolume, sfx->pan);
     #endif
 
                     sfx->samplePtr += sampleLen;
-                    sfx->sampleLength -= sampleLen*sizeof(Sint16);
+                    sfx->sampleLength -= sampleLen;
                 }
 
                 if (sfx->sampleLength <= 0) {
@@ -526,14 +526,14 @@ void LoadSfx(char *filePath, byte sfxID) {
 
                     StrCopy(sfxList[sfxID].name, filePath);
                     sfxList[sfxID].buffer = (Sint16*)convert.buf;
-                    sfxList[sfxID].length = convert.len_cvt;
+                    sfxList[sfxID].length = convert.len_cvt / sizeof(Sint16);
                     sfxList[sfxID].loaded = true;
                     SDL_FreeWAV(wav_buffer);
                 }
                 else {
                     StrCopy(sfxList[sfxID].name, filePath);
                     sfxList[sfxID].buffer = (Sint16*)wav_buffer;
-                    sfxList[sfxID].length = wav_length;
+                    sfxList[sfxID].length = wav_length / sizeof(Sint16);
                     sfxList[sfxID].loaded = true;
                 }
             }

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -171,6 +171,7 @@ void ProcessMusicStream(Sint32 *stream, size_t bytes_wanted)
                     return;
             }
 
+            // Now that we know there are enough samples, read them and mix them
             int bytes_done = SDL_AudioStreamGet(musInfo.stream, musInfo.buffer, bytes_wanted);
             if (bytes_done == -1) {
                 return;
@@ -290,7 +291,7 @@ void ProcessAudioPlayback(void *userdata, Uint8 *stream, int len)
 }
 
 #if RETRO_USING_SDL
-void ProcessAudioMixing(Sint32 *dst, const Sint16 *src, int len, int volume, signed char pan)
+void ProcessAudioMixing(Sint32 *dst, const Sint16 *src, int len, int volume, sbyte pan)
 {
     if (volume == 0)
         return;

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -21,6 +21,7 @@ ChannelInfo sfxChannels[CHANNEL_COUNT];
 MusicPlaybackInfo musInfo;
 
 #if RETRO_USING_SDL
+SDL_AudioDeviceID audioDevice;
 SDL_AudioSpec audioDeviceFormat;
 SDL_AudioStream *ogv_stream;
 
@@ -42,15 +43,15 @@ int InitAudioPlayback()
     StopAllSfx(); //"init"
 #if RETRO_USING_SDL
     SDL_AudioSpec want;
-    audioDeviceFormat.freq     = AUDIO_FREQUENCY;
-    audioDeviceFormat.format   = AUDIO_FORMAT;
-    audioDeviceFormat.samples  = AUDIO_SAMPLES;
-    audioDeviceFormat.channels = AUDIO_CHANNELS;
-    audioDeviceFormat.callback = ProcessAudioPlayback;
+    want.freq     = AUDIO_FREQUENCY;
+    want.format   = AUDIO_FORMAT;
+    want.samples  = AUDIO_SAMPLES;
+    want.channels = AUDIO_CHANNELS;
+    want.callback = ProcessAudioPlayback;
 
-    if (SDL_OpenAudio(&audioDeviceFormat, NULL) >= 0) {
+    if ((audioDevice = SDL_OpenAudioDevice(nullptr, 0, &want, &audioDeviceFormat, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE)) > 0) {
         audioEnabled = true;
-        SDL_PauseAudio(0);
+        SDL_PauseAudioDevice(audioDevice, 0);
     }
     else {
         printLog("Unable to open audio device: %s", SDL_GetError());

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -25,7 +25,7 @@ SDL_AudioSpec audioDeviceFormat;
 SDL_AudioStream *ogv_stream;
 
 #define AUDIO_FREQUENCY (44100)
-#define AUDIO_FORMAT    (0x8010) /**< Signed 16-bit samples */
+#define AUDIO_FORMAT    (AUDIO_S16SYS) /**< Signed 16-bit samples */
 #define AUDIO_SAMPLES   (0x800)
 #define AUDIO_CHANNELS  (2)
 
@@ -327,7 +327,7 @@ void ProcessAudioMixing(Sint16 *dst, const Sint16 *src, Uint32 len, int volume, 
     const Sint16 max_audioval = ((1 << (16 - 1)) - 1);
     const Sint16 min_audioval = -(1 << (16 - 1));
 
-    len /= 2;
+    len /= sizeof(Sint16);
     while (len--) {
         long sample = *src++;
         ADJUST_VOLUME(sample, volume);

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -241,8 +241,6 @@ void ProcessAudioPlayback(void *data, Uint8 *stream_uint8, int len)
 
     // Process music being played by a video
     if (videoPlaying) {
-        // TODO - Aren't the ending videos meant to play different music when the US soundtrack is enabled?
-
         // Fetch THEORAPLAY audio packets, and shove them into the SDL Audio Stream
         const THEORAPLAY_AudioPacket *packet;
 

--- a/SonicCDDecomp/Audio.hpp
+++ b/SonicCDDecomp/Audio.hpp
@@ -80,9 +80,9 @@ extern SDL_AudioSpec audioDeviceFormat;
 int InitAudioPlayback();
 
 #if RETRO_USING_SDL
-void ProcessMusicStream(void *data, Sint16 *stream, int le);
+void ProcessMusicStream(void *data, Sint16 *stream, int len);
 void ProcessAudioPlayback(void *data, Uint8 *stream, int len);
-void ProcessAudioMixing(Sint16 *dst, const Sint16 *src, Uint32 len, int volume, signed char pan);
+void ProcessAudioMixing(Sint16 *dst, const Sint16 *src, int len, int volume, signed char pan);
 
 
 inline void freeMusInfo()

--- a/SonicCDDecomp/Audio.hpp
+++ b/SonicCDDecomp/Audio.hpp
@@ -21,8 +21,8 @@ struct MusicPlaybackInfo {
     int vorbBitstream;
     SDL_AudioSpec spec;
     SDL_AudioStream *stream;
-    byte *buffer;
-    byte *extraBuffer;
+    Sint16 *buffer;
+    Sint16 *extraBuffer;
 #endif
     FileInfo fileInfo;
     bool trackLoop;
@@ -32,7 +32,7 @@ struct MusicPlaybackInfo {
 
 struct SFXInfo {
     char name[0x40];
-    byte *buffer;
+    Sint16 *buffer;
     int length;
     bool loaded;
 };
@@ -40,7 +40,7 @@ struct SFXInfo {
 struct ChannelInfo {
     int sampleStart;
     int sampleLength;
-    byte *samplePtr;
+    Sint16 *samplePtr;
     int sfxID;
     byte loopSFX;
     sbyte pan;
@@ -80,9 +80,9 @@ extern SDL_AudioSpec audioDeviceFormat;
 int InitAudioPlayback();
 
 #if RETRO_USING_SDL
-void ProcessMusicStream(void *data, Uint8 *stream, int le);
+void ProcessMusicStream(void *data, Sint16 *stream, int le);
 void ProcessAudioPlayback(void *data, Uint8 *stream, int len);
-void ProcessAudioMixing(void *sfx, Uint8 *dst, const byte *src, SDL_AudioFormat format, Uint32 len, int volume, bool music);
+void ProcessAudioMixing(void *sfx, Sint16 *dst, const Sint16 *src, SDL_AudioFormat format, Uint32 len, int volume, bool music);
 
 
 inline void freeMusInfo()

--- a/SonicCDDecomp/Audio.hpp
+++ b/SonicCDDecomp/Audio.hpp
@@ -82,7 +82,7 @@ int InitAudioPlayback();
 #if RETRO_USING_SDL
 void ProcessMusicStream(void *data, Sint16 *stream, int le);
 void ProcessAudioPlayback(void *data, Uint8 *stream, int len);
-void ProcessAudioMixing(void *sfx, Sint16 *dst, const Sint16 *src, Uint32 len, int volume, bool music);
+void ProcessAudioMixing(Sint16 *dst, const Sint16 *src, Uint32 len, int volume, signed char pan);
 
 
 inline void freeMusInfo()

--- a/SonicCDDecomp/Audio.hpp
+++ b/SonicCDDecomp/Audio.hpp
@@ -82,7 +82,7 @@ int InitAudioPlayback();
 #if RETRO_USING_SDL
 void ProcessMusicStream(void *data, Sint16 *stream, int len);
 void ProcessAudioPlayback(void *data, Uint8 *stream, int len);
-void ProcessAudioMixing(Sint16 *dst, const Sint16 *src, int len, int volume, signed char pan);
+void ProcessAudioMixing(Sint32 *dst, const Sint16 *src, int len, int volume, signed char pan);
 
 
 inline void freeMusInfo()

--- a/SonicCDDecomp/Audio.hpp
+++ b/SonicCDDecomp/Audio.hpp
@@ -78,7 +78,7 @@ int InitAudioPlayback();
 #if RETRO_USING_SDL
 void ProcessMusicStream(void *data, Sint16 *stream, int len);
 void ProcessAudioPlayback(void *data, Uint8 *stream, int len);
-void ProcessAudioMixing(Sint32 *dst, const Sint16 *src, int len, int volume, signed char pan);
+void ProcessAudioMixing(Sint32 *dst, const Sint16 *src, int len, int volume, sbyte pan);
 
 
 inline void freeMusInfo()

--- a/SonicCDDecomp/Audio.hpp
+++ b/SonicCDDecomp/Audio.hpp
@@ -17,7 +17,6 @@ struct TrackInfo {
 struct MusicPlaybackInfo {
 #if RETRO_USING_SDL
     OggVorbis_File vorbisFile;
-    unsigned long long audioLen;
     int vorbBitstream;
     SDL_AudioSpec spec;
     SDL_AudioStream *stream;
@@ -99,7 +98,6 @@ inline void freeMusInfo()
         musInfo.buffer       = nullptr;
         musInfo.extraBuffer  = nullptr;
         musInfo.stream       = nullptr;
-        musInfo.audioLen     = 0;
         musInfo.trackLoop    = false;
         musInfo.loopPoint    = 0;
         musInfo.loaded       = false;
@@ -120,7 +118,6 @@ inline void freeMusInfo()
         musInfo.musicFile    = nullptr;
         musInfo.buffer       = nullptr;
         musInfo.stream       = nullptr;
-        musInfo.audioLen     = 0;
         musInfo.pos          = 0;
         musInfo.len          = 0;
         musInfo.currentTrack = nullptr;

--- a/SonicCDDecomp/Audio.hpp
+++ b/SonicCDDecomp/Audio.hpp
@@ -30,12 +30,12 @@ struct MusicPlaybackInfo {
 struct SFXInfo {
     char name[0x40];
     Sint16 *buffer;
-    int length;
+    size_t length;
     bool loaded;
 };
 
 struct ChannelInfo {
-    int sampleLength;
+    size_t sampleLength;
     Sint16 *samplePtr;
     int sfxID;
     byte loopSFX;

--- a/SonicCDDecomp/Audio.hpp
+++ b/SonicCDDecomp/Audio.hpp
@@ -82,7 +82,7 @@ int InitAudioPlayback();
 #if RETRO_USING_SDL
 void ProcessMusicStream(void *data, Sint16 *stream, int le);
 void ProcessAudioPlayback(void *data, Uint8 *stream, int len);
-void ProcessAudioMixing(void *sfx, Sint16 *dst, const Sint16 *src, SDL_AudioFormat format, Uint32 len, int volume, bool music);
+void ProcessAudioMixing(void *sfx, Sint16 *dst, const Sint16 *src, Uint32 len, int volume, bool music);
 
 
 inline void freeMusInfo()

--- a/SonicCDDecomp/Audio.hpp
+++ b/SonicCDDecomp/Audio.hpp
@@ -18,10 +18,8 @@ struct MusicPlaybackInfo {
 #if RETRO_USING_SDL
     OggVorbis_File vorbisFile;
     int vorbBitstream;
-    SDL_AudioSpec spec;
     SDL_AudioStream *stream;
     Sint16 *buffer;
-    Sint16 *extraBuffer;
 #endif
     FileInfo fileInfo;
     bool trackLoop;
@@ -90,13 +88,10 @@ inline void freeMusInfo()
 
         if (musInfo.buffer)
             delete[] musInfo.buffer;
-        if (musInfo.extraBuffer)
-            delete[] musInfo.extraBuffer;
         if (musInfo.stream)
             SDL_FreeAudioStream(musInfo.stream);
         ov_clear(&musInfo.vorbisFile);
         musInfo.buffer       = nullptr;
-        musInfo.extraBuffer  = nullptr;
         musInfo.stream       = nullptr;
         musInfo.trackLoop    = false;
         musInfo.loopPoint    = 0;

--- a/SonicCDDecomp/Audio.hpp
+++ b/SonicCDDecomp/Audio.hpp
@@ -38,7 +38,6 @@ struct SFXInfo {
 };
 
 struct ChannelInfo {
-    int sampleStart;
     int sampleLength;
     Sint16 *samplePtr;
     int sfxID;


### PR DESCRIPTION
This overhaul enables support for arbitrary output sample rates, adds proper sample clamping, addresses a number of edgecases, and simplifies the code.

The previous mixer, while allowing SDL2 to select whatever sample rate it preferred, didn't actually support it: if a sample rate such as 11025Hz is chosen, then the audio output is choppy. This rewritten mixer corrects this issue.

I've also removed support for audio formats besides native-endian S16. The previous mixer had to decode and re-encode samples as they were being mixed, which creates overhead, and this overhead multiplies when there are multiple sounds playing at once. In the rewritten mixer, everything is mixed in native-endian S16, and the task of converting to the audio backend's native format is left to SDL2 as a post-processing step. The overhead of this conversion does not increase when there are multiple sounds playing. Even then, I think it's unlikely that a platform will prefer a format over S16, so there will likely be no conversion in the first place.

Additionally, the previous mixer had an imperfect method of clamping output: it would clamp whenever a sample is mixed into the final output, potentially introducing distortion. For example, imagine there are three samples - 0x6000, 0x6000, and -0x6000 - when the first two are added, the result is clamped to 0x7FFF, this means that when the third sample is mixed, the result is 0x1FFF. Ideally, clamping would only be performed after all samples are mixed: in this case, the result is 0x6000, as it should be.

The music decoding logic has been simplified significantly, and should now properly handle the edgecase where the requested number of samples is larger than the buffer. Looping sounds having a gap between the end of one loop and the start of another has also been corrected.