### PR TITLE
Proposal: Use YV12 internally for Video

### DIFF
--- a/SonicCDDecomp/Drawing.cpp
+++ b/SonicCDDecomp/Drawing.cpp
@@ -189,10 +189,6 @@ void RenderRenderDevice()
         }
     }
     else {
-        SDL_LockTexture(Engine.videoBuffer, NULL, (void **)&pixels, &pitch);
-        memcpy(pixels, Engine.videoFrameBuffer, pitch * videoHeight);
-        SDL_UnlockTexture(Engine.videoBuffer);
-
         SDL_RenderCopy(Engine.renderer, Engine.videoBuffer, NULL, &destScreenPos);
     }
 

--- a/SonicCDDecomp/RetroEngine.hpp
+++ b/SonicCDDecomp/RetroEngine.hpp
@@ -184,7 +184,6 @@ extern bool engineDebugMode;
 
 // Utils
 #include "Ini.hpp"
-
 #include "Math.hpp"
 #include "String.hpp"
 #include "Reader.hpp"
@@ -272,7 +271,6 @@ public:
 
     ushort *frameBuffer    = nullptr;
     ushort *frameBuffer2x  = nullptr;
-    uint *videoFrameBuffer = nullptr;
 
     bool isFullScreen = false;
 

--- a/SonicCDDecompUWP/Package.appxmanifest
+++ b/SonicCDDecompUWP/Package.appxmanifest
@@ -3,7 +3,7 @@
   <Identity
     Name="53f5dd53-e37b-4d27-8198-89ae27e15b1f"
     Publisher="CN=wamwo"
-    Version="1.0.7.0" />
+    Version="1.0.12.0" />
   <mp:PhoneIdentity PhoneProductId="53f5dd53-e37b-4d27-8198-89ae27e15b1f" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
   <Properties>
     <DisplayName>SonicCDDecompUWP</DisplayName>
@@ -18,11 +18,11 @@
   </Resources>
   <Applications>
     <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="SonicCDDecompUWP.App">
-      <uap:VisualElements DisplayName="SonicCDDecompUWP" Description="Project for a single page C++/WinRT Universal Windows Platform (UWP) app with no predefined layout"
-        Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent">
-        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png">
+      <uap:VisualElements DisplayName="Sonic CD" 
+        Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" BackgroundColor="transparent" Description="It’s time to usher the past into the future in this enhanced recreation of Sonic CD!">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" >
         </uap:DefaultTile>
-        <uap:SplashScreen Image="Assets\SplashScreen.png" />
+        <uap:SplashScreen Image="Assets\SplashScreen.png"  BackgroundColor="#000000"/>
       </uap:VisualElements>
     </Application>
   </Applications>


### PR DESCRIPTION
This PR changes the video player to use the YUV420 colour space internally, rather than RGBA. 

Most video files (including those in Sonic CD) are encoded in yuv420p, and by requesting RGBA from libtheora, we force it to do costly colour space conversion on the CPU. By using YV12 textures internally, we leave this to the GPU, the net result being vastly reduced CPU usage while playing video (in the order of about 50%)

In my testing I haven't noted any issues, however I am changing parts of video playback that seemed intentional initially, and would like feedback on these changes and potentially testing on other platforms (especially Vita)