### PR TITLE
Add Linux job to GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,23 @@ jobs:
           name: SonicCD-Windows 
           path: artifacts 
   
+  linux:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libtheora-dev libogg-dev libvorbis-dev libsdl2-dev
+      - name: Build Sonic CD
+        run: make
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: SonicCD-Linux
+          path: soniccd
+
   psvita:
     runs-on: ubuntu-latest
     container: vitasdk/vitasdk:latest


### PR DESCRIPTION
Builds on `ubuntu-20.04` instead of `ubuntu-latest` (18.04) to work around the build failing with an older version of SDL (i blame #21)