### PR TITLE
UWP improvements

### DIFF
--- a/SonicCDDecomp/RetroEngine.cpp
+++ b/SonicCDDecomp/RetroEngine.cpp
@@ -1,4 +1,8 @@
 #include "RetroEngine.hpp"
+#if RETRO_PLATFORM == RETRO_UWP
+#include <winrt/base.h>
+#include <winrt/Windows.Storage.h>
+#endif
 
 bool usingCWD        = false;
 bool engineDebugMode = false;
@@ -208,8 +212,23 @@ void RetroEngine::Init()
 {
     CalculateTrigAngles();
     GenerateBlendLookupTable();
+#if RETRO_PLATFORM == RETRO_UWP
+    static char resourcePath[256] = { 0 };
 
+    if (strlen(resourcePath) == 0) {
+        auto folder = winrt::Windows::Storage::ApplicationData::Current().LocalFolder();
+        auto path   = to_string(folder.Path());
+
+        std::copy(path.begin(), path.end(), resourcePath);
+    }
+
+    char datapath[256];
+    strcat(datapath, resourcePath);
+    strcat(datapath, "\\Data.rsdk");
+    CheckRSDKFile(datapath);
+#else
     CheckRSDKFile(BASE_PATH "Data.rsdk");
+#endif
     InitUserdata();
 
     gameMode = ENGINE_EXITGAME;

--- a/SonicCDDecompUWP/main.cpp
+++ b/SonicCDDecompUWP/main.cpp
@@ -15,6 +15,7 @@
 
 int SDL_main(int argc, char *argv[])
 {
+    SDL_SetHint(SDL_HINT_WINRT_HANDLE_BACK_BUTTON, "1");
     Engine.Init();
     Engine.Run();
 


### PR DESCRIPTION
Bug fix:
Tell system that the game is handling B button presses so that navigating back in the menu does not close the app on Xbox.

Load the data.rsdk from the apps local state folder instead of the appx meaning that a precompiled appx can be distributed legally.