### PR TITLE
Fixes for big endian, fixed music during ending FMV, improved Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS_ALL = $(shell pkg-config --cflags sdl2 vorbisfile vorbis theoradec) -Idependencies/all/theoraplay $(CXXFLAGS)
+CXXFLAGS_ALL = -MMD -MP -MF objects/$*.d $(shell pkg-config --cflags sdl2 vorbisfile vorbis theoradec) -Idependencies/all/theoraplay $(CXXFLAGS)
 LDFLAGS_ALL = $(LDFLAGS)
 LIBS_ALL = $(shell pkg-config --libs sdl2 vorbisfile vorbis theoradec) -pthread $(LIBS)
 
@@ -26,9 +26,15 @@ SOURCES = dependencies/all/theoraplay/theoraplay.c \
 		SonicCDDecomp/Userdata.cpp \
 		SonicCDDecomp/Video.cpp
 
+DEPENDENCIES = $(SOURCES:%=objects/%.d)
+
+all: soniccd
+
+include $(wildcard $(DEPENDENCIES))
+
 objects/%.o: %
 	mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS_ALL) $^ -o $@ -c
+	$(CXX) $(CXXFLAGS_ALL) $< -o $@ -c
 
 soniccd: $(SOURCES:%=objects/%.o)
 	$(CXX) $(CXXFLAGS_ALL) $(LDFLAGS_ALL) $^ -o $@ $(LIBS_ALL)

--- a/SonicCDDecomp/Animation.cpp
+++ b/SonicCDDecomp/Animation.cpp
@@ -17,12 +17,12 @@ void LoadAnimationFile(const char *filePath)
 {
     FileInfo info;
     if (LoadFile(filePath, &info)) {
-        int fileBuffer = 0;
+        byte fileBuffer = 0;
         char strBuf[0x21];
         byte sheetIDs[0x18];
         sheetIDs[0] = 0;
 
-        int sheetCount = 0;
+        byte sheetCount = 0;
         FileRead(&sheetCount, 1); // Sheet Count
 
         //Read & load each spritesheet
@@ -39,7 +39,7 @@ void LoadAnimationFile(const char *filePath)
             }
         }
 
-        int animCount = 0;
+        byte animCount = 0;
         FileRead(&animCount, 1);
         AnimationFile *animFile = &animationFileList[animationFileCount];
         animFile->animCount     = animCount;
@@ -62,10 +62,14 @@ void LoadAnimationFile(const char *filePath)
                 FileRead(&frame->sheetID, 1);
                 frame->sheetID = sheetIDs[frame->sheetID];
                 FileRead(&frame->hitboxID, 1);
-                FileRead(&frame->sprX, 1);
-                FileRead(&frame->sprY, 1);
-                FileRead(&frame->width, 1);
-                FileRead(&frame->height, 1);
+                FileRead(&fileBuffer, 1);
+                frame->sprX = fileBuffer;
+                FileRead(&fileBuffer, 1);
+                frame->sprY = fileBuffer;
+                FileRead(&fileBuffer, 1);
+                frame->width = fileBuffer;
+                FileRead(&fileBuffer, 1);
+                frame->height = fileBuffer;
 
                 sbyte buffer = 0;
                 FileRead(&buffer, 1);

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -84,7 +84,7 @@ int InitAudioPlayback()
     FileInfo info;
     FileInfo infoStore;
     char strBuffer[0x100];
-    int fileBuffer  = 0;
+    byte fileBuffer  = 0;
     int fileBuffer2 = 0;
 
     if (LoadFile("Data/Game/Gameconfig.bin", &info)) {
@@ -103,24 +103,24 @@ int InitAudioPlayback()
         strBuffer[fileBuffer] = 0;
 
         // Read Obect Names
-        int objectCount = 0;
+        byte objectCount = 0;
         FileRead(&objectCount, 1);
-        for (int o = 0; o < objectCount; ++o) {
+        for (byte o = 0; o < objectCount; ++o) {
             FileRead(&fileBuffer, 1);
             FileRead(strBuffer, fileBuffer);
             strBuffer[fileBuffer] = 0;
         }
 
         // Read Script Paths
-        for (int s = 0; s < objectCount; ++s) {
+        for (byte s = 0; s < objectCount; ++s) {
             FileRead(&fileBuffer, 1);
             FileRead(strBuffer, fileBuffer);
             strBuffer[fileBuffer] = 0;
         }
 
-        int varCnt = 0;
+        byte varCnt = 0;
         FileRead(&varCnt, 1);
-        for (int v = 0; v < varCnt; ++v) {
+        for (byte v = 0; v < varCnt; ++v) {
             FileRead(&fileBuffer, 1);
             FileRead(strBuffer, fileBuffer);
             strBuffer[fileBuffer] = 0;
@@ -130,9 +130,9 @@ int InitAudioPlayback()
         }
 
         // Read SFX
-        globalSFXCount = 0;
-        FileRead(&globalSFXCount, 1);
-        for (int s = 0; s < globalSFXCount; ++s) {
+        FileRead(&fileBuffer, 1);
+        globalSFXCount = fileBuffer;
+        for (byte s = 0; s < globalSFXCount; ++s) {
             FileRead(&fileBuffer, 1);
             FileRead(strBuffer, fileBuffer);
             strBuffer[fileBuffer] = 0;

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -512,9 +512,9 @@ void LoadSfx(char *filePath, byte sfxID)
                     sfxList[sfxID].length = wav_length / sizeof(Sint16);
                     sfxList[sfxID].loaded = true;
                 }
-            }
 
-            std::cout << sfxList[sfxID].name << std::endl;
+                std::cout << sfxList[sfxID].name << std::endl;
+            }
         }
         SDL_UnlockAudio();
 #endif

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -71,7 +71,7 @@ int InitAudioPlayback()
     // This is true of every .ogv file in the game (the Steam version, at least),
     // but it would be nice to make this dynamic. Unfortunately, THEORAPLAY's API
     // makes this awkward.
-    ogv_stream = SDL_NewAudioStream(AUDIO_F32, 2, 48000, audioDeviceFormat.format, audioDeviceFormat.channels, audioDeviceFormat.freq);
+    ogv_stream = SDL_NewAudioStream(AUDIO_F32SYS, 2, 48000, audioDeviceFormat.format, audioDeviceFormat.channels, audioDeviceFormat.freq);
     if (!ogv_stream) {
         printLog("Failed to create stream: %s", SDL_GetError());
         SDL_CloseAudioDevice(audioDevice);

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -323,8 +323,7 @@ void ProcessAudioPlayback(void *userdata, Uint8 *stream, int len)
 
             // Mix the converted audio data into the final output
             if (get != -1)
-                ProcessAudioMixing(mix_buffer, buffer, get / sizeof(Sint16), (bgmVolume * masterVolume) / MAX_VOLUME,
-                                   0); // TODO - Should we be using the music volume?
+                ProcessAudioMixing(mix_buffer, buffer, get / sizeof(Sint16), MAX_VOLUME, 0);
         }
         else {
             SDL_AudioStreamClear(ogv_stream); // Prevent leftover audio from playing at the start of the next video

--- a/SonicCDDecomp/Audio.hpp
+++ b/SonicCDDecomp/Audio.hpp
@@ -3,6 +3,10 @@
 
 #include <stdlib.h>
 
+#include <vorbis/vorbisfile.h>
+
+#include "SDL.h"
+
 #define TRACK_COUNT (0x10)
 #define SFX_COUNT (0x100)
 #define CHANNEL_COUNT (0x4)

--- a/SonicCDDecomp/RetroEngine.cpp
+++ b/SonicCDDecomp/RetroEngine.cpp
@@ -323,8 +323,8 @@ void RetroEngine::Run()
 bool RetroEngine::LoadGameConfig(const char *filePath)
 {
     FileInfo info;
-    int fileBuffer  = 0;
-    int fileBuffer2 = 0;
+    byte fileBuffer  = 0;
+    byte fileBuffer2 = 0;
     char data[0x40];
 
     if (LoadFile(filePath, &info)) {
@@ -341,23 +341,23 @@ bool RetroEngine::LoadGameConfig(const char *filePath)
         gameDescriptionText[fileBuffer] = 0;
 
         // Read Obect Names
-        int objectCount = 0;
+        byte objectCount = 0;
         FileRead(&objectCount, 1);
-        for (int o = 0; o < objectCount; ++o) {
+        for (byte o = 0; o < objectCount; ++o) {
             FileRead(&fileBuffer, 1);
-            for (int i = 0; i < fileBuffer; ++i) FileRead(&fileBuffer2, 1);
+            for (byte i = 0; i < fileBuffer; ++i) FileRead(&fileBuffer2, 1);
         }
 
         // Read Script Paths
-        for (int s = 0; s < objectCount; ++s) {
+        for (byte s = 0; s < objectCount; ++s) {
             FileRead(&fileBuffer, 1);
-            for (int i = 0; i < fileBuffer; ++i) FileRead(&fileBuffer2, 1);
+            for (byte i = 0; i < fileBuffer; ++i) FileRead(&fileBuffer2, 1);
         }
 
-        int varCount = 0;
+        byte varCount = 0;
         FileRead(&varCount, 1);
         globalVariablesCount = varCount;
-        for (int v = 0; v < varCount; ++v) {
+        for (byte v = 0; v < varCount; ++v) {
             // Read Variable Name
             FileRead(&fileBuffer, 1);
             FileRead(&globalVariableNames[v], fileBuffer);
@@ -386,19 +386,19 @@ bool RetroEngine::LoadGameConfig(const char *filePath)
         }
 
         // Read SFX
-        int sfxCount = 0;
+        byte sfxCount = 0;
         FileRead(&sfxCount, 1);
-        for (int s = 0; s < sfxCount; ++s) {
+        for (byte s = 0; s < sfxCount; ++s) {
             FileRead(&fileBuffer, 1);
-            for (int i = 0; i < fileBuffer; ++i) FileRead(&fileBuffer2, 1);
+            for (byte i = 0; i < fileBuffer; ++i) FileRead(&fileBuffer2, 1);
         }
 
         // Read Player Names
-        int playerCount = 0;
+        byte playerCount = 0;
         FileRead(&playerCount, 1);
-        for (int p = 0; p < playerCount; ++p) {
+        for (byte p = 0; p < playerCount; ++p) {
             FileRead(&fileBuffer, 1);
-            for (int i = 0; i < fileBuffer; ++i) FileRead(&fileBuffer2, 1);
+            for (byte i = 0; i < fileBuffer; ++i) FileRead(&fileBuffer2, 1);
         }
 
         for (int c = 0; c < 4; ++c) {
@@ -408,10 +408,9 @@ bool RetroEngine::LoadGameConfig(const char *filePath)
                 cat = 3;
             else if (c == 3)
                 cat = 2;
-            stageListCount[cat] = 0;
-            FileRead(&stageListCount[cat], 1);
+            FileRead(&fileBuffer, 1);
+            stageListCount[cat] = fileBuffer;
             for (int s = 0; s < stageListCount[cat]; ++s) {
-
                 // Read Stage Folder
                 FileRead(&fileBuffer, 1);
                 FileRead(&stageList[cat][s].folder, fileBuffer);
@@ -430,12 +429,14 @@ bool RetroEngine::LoadGameConfig(const char *filePath)
                 // Read Stage Mode
                 FileRead(&fileBuffer, 1);
                 stageList[cat][s].highlighted = fileBuffer;
+
             }
         }
 
         CloseFile();
         return true;
     }
+
     return false;
 }
 

--- a/SonicCDDecomp/Scene.cpp
+++ b/SonicCDDecomp/Scene.cpp
@@ -254,8 +254,8 @@ void LoadStageFiles(void)
     StopAllSfx();
     FileInfo infoStore;
     FileInfo info;
-    int fileBuffer  = 0;
-    int fileBuffer2 = 0;
+    byte fileBuffer  = 0;
+    byte fileBuffer2 = 0;
     int scriptID    = 1;
     char strBuffer[0x100];
 
@@ -279,9 +279,9 @@ void LoadStageFiles(void)
             FileRead(&fileBuffer, 1);
             FileRead(&strBuffer, fileBuffer);
 
-            int globalObjectCount = 0;
+            byte globalObjectCount = 0;
             FileRead(&globalObjectCount, 1);
-            for (int i = 0; i < globalObjectCount; ++i) {
+            for (byte i = 0; i < globalObjectCount; ++i) {
                 FileRead(&fileBuffer2, 1);
                 FileRead(strBuffer, fileBuffer2);
                 strBuffer[fileBuffer2] = 0;
@@ -296,7 +296,7 @@ void LoadStageFiles(void)
                 SetFileInfo(&infoStore);
             }
             else {
-                for (int i = 0; i < globalObjectCount; ++i) {
+                for (byte i = 0; i < globalObjectCount; ++i) {
                     FileRead(&fileBuffer2, 1);
                     FileRead(strBuffer, fileBuffer2);
                     strBuffer[fileBuffer2] = 0;
@@ -319,16 +319,16 @@ void LoadStageFiles(void)
                 SetPaletteEntry(-1, i, clr[0], clr[1], clr[2]);
             }
 
-            int stageObjectCount = 0;
+            byte stageObjectCount = 0;
             FileRead(&stageObjectCount, 1);
-            for (int i = 0; i < stageObjectCount; ++i) {
+            for (byte i = 0; i < stageObjectCount; ++i) {
                 FileRead(&fileBuffer2, 1);
                 FileRead(strBuffer, fileBuffer2);
                 strBuffer[fileBuffer2] = 0;
                 SetObjectTypeName(strBuffer, scriptID + i);
             }
             if (Engine.usingBytecode) {
-                for (int i = 0; i < stageObjectCount; ++i) {
+                for (byte i = 0; i < stageObjectCount; ++i) {
                     FileRead(&fileBuffer2, 1);
                     FileRead(strBuffer, fileBuffer2);
                     strBuffer[fileBuffer2] = 0;
@@ -339,7 +339,7 @@ void LoadStageFiles(void)
                 SetFileInfo(&infoStore);
             }
             else {
-                for (int i = 0; i < stageObjectCount; ++i) {
+                for (byte i = 0; i < stageObjectCount; ++i) {
                     FileRead(&fileBuffer2, 1);
                     FileRead(strBuffer, fileBuffer2);
                     strBuffer[fileBuffer2] = 0;
@@ -352,7 +352,8 @@ void LoadStageFiles(void)
                 }
             }
 
-            FileRead(&stageSFXCount, 1);
+            FileRead(&fileBuffer2, 1);
+            stageSFXCount = fileBuffer2;
             for (int i = 0; i < stageSFXCount; ++i) {
                 FileRead(&fileBuffer2, 1);
                 FileRead(strBuffer, fileBuffer2);
@@ -443,7 +444,7 @@ void LoadActLayout()
 {
     FileInfo info;
     if (LoadActFile(".bin", stageListPosition, &info)) {
-        int length = 0;
+        byte length = 0;
         FileRead(&length, 1);
         titleCardWord2 = (byte)length;
         for (int i = 0; i < length; i++) {
@@ -471,7 +472,7 @@ void LoadActLayout()
 
         for (int i = 0; i < 0x10000; ++i) stageLayouts[0].tiles[i] = 0;
 
-        int fileBuffer = 0;
+        byte fileBuffer = 0;
         for (int y = 0; y < stageLayouts[0].height; ++y) {
             ushort *tiles = &stageLayouts[0].tiles[(y * 0x100)];
             for (int x = 0; x < stageLayouts[0].width; ++x) {
@@ -538,8 +539,8 @@ void LoadStageBackground()
 
     FileInfo info;
     if (LoadStageFile("Backgrounds.bin", stageListPosition, &info)) {
-        int fileBuffer = 0;
-        int layerCount = 0;
+        byte fileBuffer = 0;
+        byte layerCount = 0;
         FileRead(&layerCount, 1);
         FileRead(&hParallax.entryCount, 1);
         for (int i = 0; i < hParallax.entryCount; ++i) {
@@ -658,7 +659,7 @@ void LoadStageCollisions()
     FileInfo info;
     if (LoadStageFile("CollisionMasks.bin", stageListPosition, &info)) {
 
-        int fileBuffer = 0;
+        byte fileBuffer = 0;
         int tileIndex  = 0;
         for (int t = 0; t < 1024; ++t) {
             for (int p = 0; p < 2; ++p) {
@@ -827,7 +828,8 @@ void LoadStageGIFFile(int stageID)
 {
     FileInfo info;
     if (LoadStageFile("16x16Tiles.gif", stageID, &info)) {
-        int fileBuffer = 0;
+        byte fileBuffer = 0;
+        int fileBuffer2 = 0;
 
         SetFilePosition(6); // GIF89a
         FileRead(&fileBuffer, 1);
@@ -863,17 +865,17 @@ void LoadStageGIFFile(int stageID)
         FileRead(&fileBuffer, 1);
         while (fileBuffer != ',') FileRead(&fileBuffer, 1); // gif image start identifier
 
-        FileRead(&fileBuffer, 2);
-        FileRead(&fileBuffer, 2);
-        FileRead(&fileBuffer, 2);
-        FileRead(&fileBuffer, 2);
+        FileRead(&fileBuffer2, 2);
+        FileRead(&fileBuffer2, 2);
+        FileRead(&fileBuffer2, 2);
+        FileRead(&fileBuffer2, 2);
         FileRead(&fileBuffer, 1);
         bool interlaced = (fileBuffer & 0x40) >> 6;
         if ((unsigned int)fileBuffer >> 7 == 1) {
             int c = 128;
             do {
                 ++c;
-                FileRead(&fileBuffer, 3);
+                FileRead(&fileBuffer2, 3);
             } while (c != 256);
         }
 
@@ -892,7 +894,7 @@ void LoadStageGFXFile(int stageID)
 {
     FileInfo info;
     if (LoadStageFile("16x16Tiles.gfx", stageID, &info)) {
-        int fileBuffer = 0;
+        byte fileBuffer = 0;
         FileRead(&fileBuffer, 1);
         int width = fileBuffer << 8;
         FileRead(&fileBuffer, 1);

--- a/SonicCDDecomp/Script.cpp
+++ b/SonicCDDecomp/Script.cpp
@@ -1671,7 +1671,7 @@ void LoadBytecode(int stageListID, int scriptID)
 
     FileInfo info;
     if (LoadFile(scriptPath, &info)) {
-        int fileBuffer = 0;
+        byte fileBuffer = 0;
         int *scrData   = &scriptData[scriptCodePos];
         FileRead(&fileBuffer, 1);
         int scriptDataCount = fileBuffer;

--- a/SonicCDDecomp/Sprite.cpp
+++ b/SonicCDDecomp/Sprite.cpp
@@ -38,7 +38,7 @@ byte TraceGifPrefix(uint *prefix, int code, int clearCode);
 
 void InitGifDecoder()
 {
-    int val = 0;
+    byte val = 0;
     FileRead(&val, 1);
     gifDecoder.fileState      = LOADING_IMAGE;
     gifDecoder.position       = 0;
@@ -262,7 +262,7 @@ int LoadBMPFile(const char *filePath, byte sheetID)
         GFXSurface *surface = &gfxSurface[sheetID];
         StrCopy(surface->fileName, filePath);
 
-        int fileBuffer = 0;
+        byte fileBuffer = 0;
 
         SetFilePosition(18);
         FileRead(&fileBuffer, 1);
@@ -319,7 +319,7 @@ int LoadGIFFile(const char *filePath, byte sheetID)
         GFXSurface *surface = &gfxSurface[sheetID];
         StrCopy(surface->fileName, filePath);
 
-        int fileBuffer = 0;
+        byte fileBuffer = 0;
 
         SetFilePosition(6); // GIF89a
         FileRead(&fileBuffer, 1);
@@ -394,7 +394,7 @@ int LoadGFXFile(const char *filePath, byte sheetID)
         GFXSurface *surface = &gfxSurface[sheetID];
         StrCopy(surface->fileName, filePath);
 
-        int fileBuffer = 0;
+        byte fileBuffer = 0;
         FileRead(&fileBuffer, 1);
         surface->width = fileBuffer << 8;
         FileRead(&fileBuffer, 1);
@@ -455,7 +455,7 @@ int LoadRSVFile(const char *filePath, byte sheetID)
         videoData         = sheetID;
         currentVideoFrame = 0;
 
-        int fileBuffer = 0;
+        byte fileBuffer = 0;
 
         FileRead(&fileBuffer, 1);
         videoFrameCount = fileBuffer;

--- a/SonicCDDecomp/Sprite.cpp
+++ b/SonicCDDecomp/Sprite.cpp
@@ -320,6 +320,7 @@ int LoadGIFFile(const char *filePath, byte sheetID)
         StrCopy(surface->fileName, filePath);
 
         byte fileBuffer = 0;
+        byte fileBuffer2[2];
 
         SetFilePosition(6); // GIF89a
         FileRead(&fileBuffer, 1);
@@ -351,10 +352,10 @@ int LoadGIFFile(const char *filePath, byte sheetID)
         FileRead(&fileBuffer, 1);
         while (fileBuffer != ',') FileRead(&fileBuffer, 1); // gif image start identifier
 
-        FileRead(&fileBuffer, 2);
-        FileRead(&fileBuffer, 2);
-        FileRead(&fileBuffer, 2);
-        FileRead(&fileBuffer, 2);
+        FileRead(fileBuffer2, 2);
+        FileRead(fileBuffer2, 2);
+        FileRead(fileBuffer2, 2);
+        FileRead(fileBuffer2, 2);
         FileRead(&fileBuffer, 1);
         bool interlaced = (fileBuffer & 0x40) >> 6;
         if (fileBuffer >> 7 == 1) {

--- a/SonicCDDecomp/Text.cpp
+++ b/SonicCDDecomp/Text.cpp
@@ -7,7 +7,7 @@ FontCharacter fontCharacterList[FONTCHAR_COUNT];
 
 void LoadFontFile(const char *filePath)
 {
-    int fileBuffer = 0;
+    byte fileBuffer = 0;
     int cnt        = 0;
     FileInfo info;
     if (LoadFile(filePath, &info)) {
@@ -298,9 +298,9 @@ void LoadConfigListText(TextMenu *menu, int listNo)
 {
     FileInfo info;
     char strBuf[0x100];
-    int fileBuffer = 0;
-    int count      = 0;
-    int strLen     = 0;
+    byte fileBuffer = 0;
+    byte count      = 0;
+    byte strLen     = 0;
     if (LoadFile("Data/Game/GameConfig.bin", &info)) {
         // Name
         FileRead(&strLen, 1);

--- a/SonicCDDecomp/Video.cpp
+++ b/SonicCDDecomp/Video.cpp
@@ -93,7 +93,7 @@ void UpdateVideoFrame()
     if (videoPlaying) {
         if (videoFrameCount > currentVideoFrame) {
             GFXSurface *surface = &gfxSurface[videoData];
-            int fileBuffer      = 0;
+            byte fileBuffer      = 0;
             FileRead(&fileBuffer, 1);
             videoFilePos += fileBuffer;
             FileRead(&fileBuffer, 1);

--- a/SonicCDDecomp/Video.hpp
+++ b/SonicCDDecomp/Video.hpp
@@ -1,6 +1,8 @@
 #ifndef VIDEO_H
 #define VIDEO_H
 
+#include <theoraplay.h>
+
 extern int currentVideoFrame;
 extern int videoFrameCount;
 extern int videoWidth;


### PR DESCRIPTION
These commits are cherry-picked from my Wii U port. The Wii U uses a PowerPC CPU in big-endian mode, so I had to fix some little-endian dependencies in the code.

I also fixed the ending FMV being mute, which only happens when it plays after the final boss: the Visual Mode option doesn't have this issue.

Additionally, I added dependency tracking to the Makefile, so that if you edit a .h file, the Makefile will recompile the .cpp files that include it.