### PR TITLE
Removed MSYS2 Intruction, Can't use exe without MSYS2 installed. Tweaked Arch Linux instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,6 @@ Even if your platform isn't supported by the official releases, you **must** buy
 * Clone the repo, then follow the instructions in the [depencencies readme for Windows](./dependencies/windows/dependencies.txt) to setup dependencies, then build via the Visual Studio solution
 * or grab a prebuilt executable from the releases section
 
-## Windows via MSYS2:
-* Download the newest version of the MSYS2 installer from [here](https://github.com/msys2/msys2-installer/releases) and install it.
-* Run the `MINGW64` prompt (from the windows Start Menu/MSYS2 64-bit/MSYS2 MinGW 64-bit), when the program starts enter `pacman -Syuu` in the prompt and hit Enter. Press `Y` when it asks if you want to update packages. If it asks you to close the prompt, do so, then restart it and run the same command again. This updates the packages to their latest versions.
-* Now install the dependencies with the following command: `pacman -S make git mingw-w64-i686-gcc mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL2 mingw-w64-x86_64-libogg mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libtheora`
-* Clone the repo with the following command: `git clone https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation.git`
-* Go into the repo you just cloned with `cd Sonic-CD-11-Decompilation`
-* Then run `make -j4` (-j switch is optional but will make building faster, it's based on the number of cores you have +1 so 8 cores wold be -j9)
-
 ## Windows UWP (Phone, Xbox, etc.):
 * Clone the repo, then follow the instructions in the [depencencies readme for Windows](./dependencies/windows/dependencies.txt) and [depencencies readme for UWP](./dependencies/win-uwp/dependencies.txt) to setup dependencies, copy your `Data.rsdk` and `videos` folder into `SonicCDDecompUWP`, then build and deploy via the UWP Visual Studio solution
 
@@ -56,7 +48,7 @@ Even if your platform isn't supported by the official releases, you **must** buy
 ## Linux:
 * To setup your build enviroment and library dependecies run the following commands:
 * Ubuntu (Mint, Pop!_OS, etc...): `sudo apt install build-essential git libsdl2-dev libvorbis-dev libogg-dev libtheora-dev`
-* Arch Linux: `sudo pacman -Sy base-devel git sdl2 libvorbis libogg libtheora`
+* Arch Linux: `sudo pacman -S base-devel git sdl2 libvorbis libogg libtheora`
 * Clone the repo with the following command: `git clone https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation.git`
 * Go into the repo you just cloned with `cd Sonic-CD-11-Decompilation`
 * Then run `make -j4` (-j switch is optional but will make building faster, it's based on the number of cores you have +1 so 8 cores wold be -j9)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ Even if your platform isn't supported by the official releases, you **must** buy
 ## Windows UWP (Phone, Xbox, etc.):
 * Clone the repo, then follow the instructions in the [depencencies readme for Windows](./dependencies/windows/dependencies.txt) and [depencencies readme for UWP](./dependencies/win-uwp/dependencies.txt) to setup dependencies, copy your `Data.rsdk` and `videos` folder into `SonicCDDecompUWP`, then build and deploy via the UWP Visual Studio solution
 
+Windows via MSYS2 (64-bit Only):
+
+*Download the newest version of the MSYS2 installer from here and install it.
+*Run the MINGW64 prompt (from the windows Start Menu/MSYS2 64-bit/MSYS2 MinGW 64-bit), when the program starts enter pacman -Syuu in the prompt and hit Enter. Press Y when it asks if you want to update packages. If it asks you to close the prompt, do so, then restart it and run the same command again. This updates the packages to their latest versions.
+*Now install the dependencies with the following command: pacman -S make git mingw-w64-i686-gcc mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL2 mingw-w64-x86_64-libogg mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libtheora
+*Clone the repo with the following command: git clone https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation.git
+*Go into the repo you just cloned with cd Sonic-CD-11-Decompilation
+*Then run make CXX=x86_64-w64-mingw32-g++ CXXFLAGS=-static -j4 (-j switch is optional but will make building faster, it's based on the number of cores you have +1 so 8 cores wold be -j9)
+
+
 ## Mac:
 * Clone the repo, then follow the instructions in the [depencencies readme for Mac](./dependencies/mac/dependencies.txt) to setup dependencies, then build via the Xcode project
 * or grab a prebuilt executable from the releases section


### PR DESCRIPTION
Arch Linux tweak referenced here: https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation/pull/108#issuecomment-766160230

MSYS2 issue referenced here: https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation/pull/108#issuecomment-766161797

The executable built in MSYS2 won't work on a machine without MSYS2 installed. I fiddled around with the makefile as much as I could to fix this, I made a little progress but ran into library linking errors. It's beyond my ability.