### PR TITLE
Fixed MSYS2 building & Restored instructions with a few tweaks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-CXXFLAGS_ALL = $(shell pkg-config --cflags sdl2 vorbisfile vorbis theoradec) -Idependencies/all/theoraplay $(CXXFLAGS)
+CXXFLAGS_ALL = $(shell pkg-config --cflags --static sdl2 vorbisfile vorbis theoradec) -Idependencies/all/theoraplay $(CXXFLAGS)
 LDFLAGS_ALL = $(LDFLAGS)
-LIBS_ALL = $(shell pkg-config --libs sdl2 vorbisfile vorbis theoradec) -pthread $(LIBS)
+LIBS_ALL = $(shell pkg-config --libs --static sdl2 vorbisfile vorbis theoradec) -pthread $(LIBS)
 
 SOURCES = dependencies/all/theoraplay/theoraplay.c \
 		SonicCDDecomp/Animation.cpp \

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ Even if your platform isn't supported by the official releases, you **must** buy
 ## Windows UWP (Phone, Xbox, etc.):
 * Clone the repo, then follow the instructions in the [depencencies readme for Windows](./dependencies/windows/dependencies.txt) and [depencencies readme for UWP](./dependencies/win-uwp/dependencies.txt) to setup dependencies, copy your `Data.rsdk` and `videos` folder into `SonicCDDecompUWP`, then build and deploy via the UWP Visual Studio solution
 
-Windows via MSYS2 (64-bit Only):
+## Windows via MSYS2 (64-bit Only):
 
-*Download the newest version of the MSYS2 installer from here and install it.
-*Run the MINGW64 prompt (from the windows Start Menu/MSYS2 64-bit/MSYS2 MinGW 64-bit), when the program starts enter pacman -Syuu in the prompt and hit Enter. Press Y when it asks if you want to update packages. If it asks you to close the prompt, do so, then restart it and run the same command again. This updates the packages to their latest versions.
-*Now install the dependencies with the following command: pacman -S make git mingw-w64-i686-gcc mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL2 mingw-w64-x86_64-libogg mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libtheora
-*Clone the repo with the following command: git clone https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation.git
-*Go into the repo you just cloned with cd Sonic-CD-11-Decompilation
-*Then run make CXX=x86_64-w64-mingw32-g++ CXXFLAGS=-static -j4 (-j switch is optional but will make building faster, it's based on the number of cores you have +1 so 8 cores wold be -j9)
+* Download the newest version of the MSYS2 installer from [here](https://www.msys2.org/) and install it.
+* Run the MINGW64 prompt (from the windows Start Menu/MSYS2 64-bit/MSYS2 MinGW 64-bit), when the program starts enter `pacman -Syuu` in the prompt and hit Enter. Press `Y` when it asks if you want to update packages. If it asks you to close the prompt, do so, then restart it and run the same command again. This updates the packages to their latest versions.
+* Now install the dependencies with the following command: `pacman -S make git mingw-w64-i686-gcc mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL2 mingw-w64-x86_64-libogg mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libtheora`
+* Clone the repo with the following command: `git clone https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation.git`
+* Go into the repo you just cloned with `cd Sonic-CD-11-Decompilation`
+* Then run `make CXX=x86_64-w64-mingw32-g++ CXXFLAGS=-static -j4` (-j switch is optional but will make building faster, it's based on the number of cores you have +1 so 8 cores wold be -j9)
 
 
 ## Mac:


### PR DESCRIPTION
Thanks to this comment here: https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation/pull/57#issuecomment-766197669 I managed to get a working exe running without MSYS2, it's a little bit hacked in but it will build fine and it doesn't screw up the linux build.