### PR TITLE
Fix filename case of GameConfig.bin in Audio.cpp

### DIFF
--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -102,7 +102,7 @@ int InitAudioPlayback()
     byte fileBuffer  = 0;
     int fileBuffer2 = 0;
 
-    if (LoadFile("Data/Game/Gameconfig.bin", &info)) {
+    if (LoadFile("Data/Game/GameConfig.bin", &info)) {
         infoStore = info;
 
         FileRead(&fileBuffer, 1);


### PR DESCRIPTION
Similar to https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation/pull/173
> For some reason, `GameConfig.bin` was written as `Gameconfig.bin` here (all other instances properly use the former), which resulted in sound effects being missing/bugged if running on a case sensitive filesystem (e.g. Linux)