### PR TITLE
Wii U port (and the Reader.cpp overhaul it required)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ endif
 
 CXXFLAGS_ALL += -MMD -MP -MF objects/$*.d $(shell pkg-config --cflags $(PKG_CONFIG_STATIC_FLAG) sdl2 vorbisfile vorbis theoradec) -Idependencies/all/theoraplay $(CXXFLAGS)
 LDFLAGS_ALL += $(LDFLAGS)
-LIBS_ALL += $(shell pkg-config --libs $(PKG_CONFIG_STATIC_FLAG) sdl2 vorbisfile vorbis theoradec) -pthread $(LIBS)
+LIBS_ALL += $(shell pkg-config --libs $(PKG_CONFIG_STATIC_FLAG) sdl2 vorbisfile vorbis theoradec) $(LIBS)
 
 SOURCES = \
   dependencies/all/theoraplay/theoraplay.c \

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,19 @@ ifeq ($(STATIC),1)
   CXXFLAGS_ALL += -static
 endif
 
-CXXFLAGS_ALL += -MMD -MP -MF objects/$*.d $(shell pkg-config --cflags $(PKG_CONFIG_STATIC_FLAG) sdl2 vorbisfile vorbis theoradec) -Idependencies/all/theoraplay $(CXXFLAGS)
-LDFLAGS_ALL += $(LDFLAGS)
-LIBS_ALL += $(shell pkg-config --libs $(PKG_CONFIG_STATIC_FLAG) sdl2 vorbisfile vorbis theoradec) $(LIBS)
+PKG_CONFIG = pkg-config
 
 ifeq ($(WIIU),1)
   include $(DEVKITPRO)/wut/share/wut_rules
   CXXFLAGS_ALL += -D__WIIU__ -D__WUT__ -ffunction-sections -I$(WUT_ROOT)/include
   LDFLAGS_ALL += $(MACHDEP) $(RPXSPECS) -L$(WUT_ROOT)/lib
   LIBS_ALL += -lwut
+  PKG_CONFIG = $(DEVKITPRO)/portlibs/wiiu/bin/powerpc-eabi-pkg-config
 endif
+
+CXXFLAGS_ALL += -MMD -MP -MF objects/$*.d $(shell $(PKG_CONFIG) --cflags $(PKG_CONFIG_STATIC_FLAG) sdl2 vorbisfile vorbis theoradec) -Idependencies/all/theoraplay $(CXXFLAGS)
+LDFLAGS_ALL += $(LDFLAGS)
+LIBS_ALL += $(shell $(PKG_CONFIG) --libs $(PKG_CONFIG_STATIC_FLAG) sdl2 vorbisfile vorbis theoradec) $(LIBS)
 
 SOURCES = \
   dependencies/all/theoraplay/theoraplay.c \

--- a/README.md
+++ b/README.md
@@ -42,13 +42,12 @@ Even if your platform isn't supported by the official releases, you **must** buy
 * Clone the repo, then follow the instructions in the [depencencies readme for Windows](./dependencies/windows/dependencies.txt) and [depencencies readme for UWP](./dependencies/win-uwp/dependencies.txt) to setup dependencies, copy your `Data.rsdk` and `videos` folder into `SonicCDDecompUWP`, then build and deploy via the UWP Visual Studio solution
 
 ## Windows via MSYS2 (64-bit Only):
-
 * Download the newest version of the MSYS2 installer from [here](https://www.msys2.org/) and install it.
 * Run the MINGW64 prompt (from the windows Start Menu/MSYS2 64-bit/MSYS2 MinGW 64-bit), when the program starts enter `pacman -Syuu` in the prompt and hit Enter. Press `Y` when it asks if you want to update packages. If it asks you to close the prompt, do so, then restart it and run the same command again. This updates the packages to their latest versions.
 * Now install the dependencies with the following command: `pacman -S make git mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL2 mingw-w64-x86_64-libogg mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libtheora`
 * Clone the repo with the following command: `git clone https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation.git`
 * Go into the repo you just cloned with `cd Sonic-CD-11-Decompilation`
-* Then run `make CXXFLAGS=-O2 CXX=x86_64-w64-mingw32-g++ STATIC=1 -j5` (-j switch is optional but will make building faster, it's based on the number of cores you have +1 so 8 cores wold be -j9)
+* Then run `make CXXFLAGS=-O2 CXX=x86_64-w64-mingw32-g++ STATIC=1 -j5` (-j switch is optional but will make building faster, it's based on the number of cores you have +1 so 8 cores would be -j9)
 
 
 ## Mac:
@@ -61,7 +60,7 @@ Even if your platform isn't supported by the official releases, you **must** buy
 * Arch Linux: `sudo pacman -S base-devel git sdl2 libvorbis libogg libtheora`
 * Clone the repo with the following command: `git clone https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation.git`
 * Go into the repo you just cloned with `cd Sonic-CD-11-Decompilation`
-* Then run `make CXXFLAGS=-O2 -j5` (-j switch is optional but will make building faster, it's based on the number of cores you have +1 so 8 cores wold be -j9)
+* Then run `make CXXFLAGS=-O2 -j5` (-j switch is optional but will make building faster, it's based on the number of cores you have +1 so 8 cores would be -j9)
 
 ## iOS:
 * Clone the repo, then follow the instructions in the [depencencies readme for iOS](./dependencies/ios/dependencies.txt) to setup dependencies, then build via the Xcode project
@@ -69,6 +68,13 @@ Even if your platform isn't supported by the official releases, you **must** buy
 ## PS Vita:
 * Ensure you have Docker installed and run the script `build.sh` from `SonicCD.Vita`. If you are on Windows, WSL2 is recommended.
 NOTE: You would need to copy Sonic CD game data into `ux0:data/SonicCD` to boot the game.
+
+## Wii U:
+* Install [devkitPPC](https://devkitpro.org/wiki/Getting_Started), and its `wiiu-dev` and `wiiu-sdl2` packages.
+* Build and install the `ppc-libtheora` package in the `dependencies/wii-u` folder (`makepkg -cirs` should work).
+* Compile the engine with `make CXXFLAGS=-O2 WIIU=1 -j5` (-j switch is optional but will make building faster, it's based on the number of cores you have +1 so 8 cores would be -j9).
+* The compiled engine can be found in the `bin` folder, named `soniccd.rpx`. This can be copied to your SD card's `wiiu/apps` folder, and then ran through the Homebrew Launcher.
+* You must copy Sonic CD's assets into a `SonicCD` folder on the root of your SD card.
 
 ## Other platforms:
 Currently the only "officially" supported platforms are the ones listed above, however the backend uses libogg, libvorbis, libtheora & SDL2 to power it, so the codebase is very multiplatform.

--- a/SonicCDDecomp/Animation.cpp
+++ b/SonicCDDecomp/Animation.cpp
@@ -15,8 +15,7 @@ int hitboxCount = 0;
 
 void LoadAnimationFile(const char *filePath)
 {
-    FileInfo info;
-    if (LoadFile(filePath, &info)) {
+    if (LoadFile(filePath)) {
         byte fileBuffer = 0;
         char strBuf[0x21];
         byte sheetIDs[0x18];
@@ -32,6 +31,7 @@ void LoadAnimationFile(const char *filePath)
                 int i = 0;
                 for (; i < fileBuffer; ++i) FileRead(&strBuf[i], 1);
                 strBuf[i] = 0;
+                FileInfo info;
                 GetFileInfo(&info);
                 CloseFile();
                 sheetIDs[s] = AddGraphicsFile(strBuf);

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -97,14 +97,11 @@ int InitAudioPlayback()
 #endif
 
     FileInfo info;
-    FileInfo infoStore;
     char strBuffer[0x100];
     byte fileBuffer  = 0;
     int fileBuffer2 = 0;
 
     if (LoadFile("Data/Game/GameConfig.bin", &info)) {
-        infoStore = info;
-
         FileRead(&fileBuffer, 1);
         FileRead(strBuffer, fileBuffer);
         strBuffer[fileBuffer] = 0;
@@ -152,9 +149,9 @@ int InitAudioPlayback()
             FileRead(strBuffer, fileBuffer);
             strBuffer[fileBuffer] = 0;
 
-            GetFileInfo(&infoStore);
+            GetFileInfo(&info);
             LoadSfx(strBuffer, s);
-            SetFileInfo(&infoStore);
+            SetFileInfo(&info);
         }
 
         CloseFile();

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -320,8 +320,8 @@ void ProcessAudioPlayback(void *userdata, Uint8 *stream, int len)
             StopMusic();
 
         if (LoadFile(trackPtr->fileName, &musInfo.fileInfo)) {
-            cFileHandleStream = cFileHandle;
-            cFileHandle                  = nullptr;
+            cFileStream.handle = cFile.handle;
+            cFile.handle                  = nullptr;
 
             musInfo.trackLoop = trackPtr->trackLoop;
             musInfo.loopPoint = trackPtr->loopPoint;

--- a/SonicCDDecomp/Audio.cpp
+++ b/SonicCDDecomp/Audio.cpp
@@ -98,12 +98,11 @@ int InitAudioPlayback()
 
 #endif
 
-    FileInfo info;
     char strBuffer[0x100];
     byte fileBuffer  = 0;
     int fileBuffer2 = 0;
 
-    if (LoadFile("Data/Game/GameConfig.bin", &info)) {
+    if (LoadFile("Data/Game/GameConfig.bin")) {
         FileRead(&fileBuffer, 1);
         FileRead(strBuffer, fileBuffer);
         strBuffer[fileBuffer] = 0;
@@ -151,6 +150,7 @@ int InitAudioPlayback()
             FileRead(strBuffer, fileBuffer);
             strBuffer[fileBuffer] = 0;
 
+            FileInfo info;
             GetFileInfo(&info);
             LoadSfx(strBuffer, s);
             SetFileInfo(&info);
@@ -169,27 +169,31 @@ int InitAudioPlayback()
 #if RETRO_USING_SDL1 || RETRO_USING_SDL2
 size_t readVorbis(void *mem, size_t size, size_t nmemb, void *ptr)
 {
-    MusicPlaybackInfo *info = (MusicPlaybackInfo *)ptr;
-    return FileRead(mem, (int)(size * nmemb), &cFileStream) / size;
+    File *file = (File*)ptr;
+    return FileRead(mem, (int)(size * nmemb), file) / size;
 }
 int seekVorbis(void *ptr, ogg_int64_t offset, int whence)
 {
-    MusicPlaybackInfo *info = (MusicPlaybackInfo *)ptr;
+    File *file = (File*)ptr;
     switch (whence) {
         case SEEK_SET: whence = 0; break;
-        case SEEK_CUR: whence = (int)GetFilePosition(&cFileStream); break;
-        case SEEK_END: whence = info->fileInfo.fileSize; break;
+        case SEEK_CUR: whence = (int)GetFilePosition(file); break;
+        case SEEK_END: whence = file->info.fileSize; break;
         default: break;
     }
-    SetFilePosition((int)(whence + offset), &cFileStream);
-    return GetFilePosition(&cFileStream) <= info->fileInfo.fileSize;
+    SetFilePosition((int)(whence + offset), file);
+    return GetFilePosition(file) <= file->info.fileSize;
 }
 long tellVorbis(void *ptr)
 {
-    MusicPlaybackInfo *info = (MusicPlaybackInfo *)ptr;
-    return GetFilePosition(&cFileStream);
+    File *file = (File*)ptr;
+    return GetFilePosition(file);
 }
-int closeVorbis(void *ptr) { return CloseFile(&cFileStream); }
+int closeVorbis(void *ptr)
+{
+    File *file = (File*)ptr;
+    return CloseFile(file);
+}
 #endif
 
 void ProcessMusicStream(Sint32 *stream, size_t bytes_wanted)
@@ -318,7 +322,7 @@ void ProcessAudioPlayback(void *userdata, Uint8 *stream, int len)
         if (musInfo.loaded)
             StopMusic();
 
-        if (LoadFile(trackPtr->fileName, &musInfo.fileInfo, &cFileStream)) {
+        if (LoadFile(trackPtr->fileName, &cFileStream)) {
 
             musInfo.trackLoop = trackPtr->trackLoop;
             musInfo.loopPoint = trackPtr->loopPoint;
@@ -332,7 +336,7 @@ void ProcessAudioPlayback(void *userdata, Uint8 *stream, int len)
             callbacks.tell_func  = tellVorbis;
             callbacks.close_func = closeVorbis;
 
-            int error = ov_open_callbacks(&musInfo, &musInfo.vorbisFile, NULL, 0, callbacks);
+            int error = ov_open_callbacks(&cFileStream, &musInfo.vorbisFile, NULL, 0, callbacks);
             if (error != 0) {
             }
 
@@ -594,22 +598,21 @@ void LoadSfx(char *filePath, byte sfxID)
     if (!audioEnabled)
         return;
 
-    FileInfo info;
     char fullPath[0x80];
 
     StrCopy(fullPath, "Data/SoundFX/");
     StrAdd(fullPath, filePath);
 
-    if (LoadFile(fullPath, &info)) {
-        byte *sfx = new byte[info.fileSize];
-        FileRead(sfx, info.fileSize);
+    if (LoadFile(fullPath)) {
+        byte *sfx = new byte[cFile.info.fileSize];
+        FileRead(sfx, cFile.info.fileSize);
         CloseFile();
 
 #if RETRO_USING_SDL1 || RETRO_USING_SDL2
         SDL_LockAudio();
-        SDL_RWops *src = SDL_RWFromMem(sfx, info.fileSize);
+        SDL_RWops *src = SDL_RWFromMem(sfx, cFile.info.fileSize);
         if (src == NULL) {
-            printLog("Unable to open sfx: %s", info.fileName);
+            printLog("Unable to open sfx: %s", cFile.info.fileName);
         }
         else {
             SDL_AudioSpec wav_spec;
@@ -620,7 +623,7 @@ void LoadSfx(char *filePath, byte sfxID)
             SDL_RWclose(src);
             delete[] sfx;
             if (wav == NULL) {
-                printLog("Unable to read sfx: %s", info.fileName);
+                printLog("Unable to read sfx: %s", cFile.info.fileName);
             }
             else {
                 SDL_AudioCVT convert;

--- a/SonicCDDecomp/Audio.hpp
+++ b/SonicCDDecomp/Audio.hpp
@@ -32,7 +32,6 @@ struct MusicPlaybackInfo {
     SDL_AudioStream *stream;
 #endif
     Sint16 *buffer;
-    FileInfo fileInfo;
     bool trackLoop;
     uint loopPoint;
     bool loaded;

--- a/SonicCDDecomp/Palette.cpp
+++ b/SonicCDDecomp/Palette.cpp
@@ -20,13 +20,12 @@ int paletteMode = 0;
 
 void LoadPalette(const char *filePath, int paletteID, int startPaletteIndex, int startIndex, int endIndex)
 {
-    FileInfo info;
     char fullPath[0x80];
 
     StrCopy(fullPath, "Data/Palettes/");
     StrAdd(fullPath, filePath);
 
-    if (LoadFile(fullPath, &info)) {
+    if (LoadFile(fullPath)) {
         SetFilePosition(3 * startIndex);
         if (paletteID >= PALETTE_COUNT || paletteID < 0)
             paletteID = 0;

--- a/SonicCDDecomp/Reader.cpp
+++ b/SonicCDDecomp/Reader.cpp
@@ -283,9 +283,11 @@ size_t FileRead(void *dest, int size, File *file)
     if (file->info.readPos <= file->info.fileSize) {
         if (Engine.usingDataFile) {
             while (bytes_read != size) {
+                if (ReachedEndOfFile(file))
+                    break;
+
                 if (file->info.bufferPosition == file->readSize)
-                    if (FillFileBuffer(file) == 0)
-                        break;
+                    FillFileBuffer(file);
 
                 *data = encryptionStringB[file->info.eStringPosB] ^ file->info.eStringNo ^ file->fileBuffer[file->info.bufferPosition++];
                 if (file->info.eNybbleSwap)
@@ -322,9 +324,11 @@ size_t FileRead(void *dest, int size, File *file)
         }
         else {
             while (bytes_read != size) {
+                if (ReachedEndOfFile(file))
+                    break;
+
                 if (file->info.bufferPosition == file->readSize)
-                    if (FillFileBuffer(file) == 0)
-                        break;
+                    FillFileBuffer(file);
 
                 *data++ = file->fileBuffer[file->info.bufferPosition++];
                 ++bytes_read;

--- a/SonicCDDecomp/Reader.cpp
+++ b/SonicCDDecomp/Reader.cpp
@@ -57,7 +57,7 @@ bool LoadFile(const char *filePath, FileInfo *fileInfo, File *file)
         file->info.bufferPosition = 0;
         file->readSize       = 0;
         file->info.readPos        = 0;
-        if (!ParseVirtualFileSystem(fileInfo, file)) {
+        if (!ParseVirtualFileSystem(fileInfo->fileName, file)) {
             fClose(file->handle);
             file->handle = NULL;
             printLog("Couldn't load file '%s'", filePath);
@@ -100,7 +100,7 @@ bool LoadFile(const char *filePath, FileInfo *fileInfo, File *file)
     return true;
 }
 
-bool ParseVirtualFileSystem(FileInfo *fileInfo, File *file)
+bool ParseVirtualFileSystem(const char *filePath, File *file)
 {
     char filename[0x50];
     char fullFilename[0x50];
@@ -114,18 +114,18 @@ bool ParseVirtualFileSystem(FileInfo *fileInfo, File *file)
 
     int j             = 0;
     file->info.virtualFileOffset = 0;
-    for (int i = 0; fileInfo->fileName[i]; i++) {
-        if (fileInfo->fileName[i] == '/') {
+    for (int i = 0; filePath[i]; i++) {
+        if (filePath[i] == '/') {
             fNamePos = i;
             j        = 0;
         }
         else {
             ++j;
         }
-        fullFilename[i] = fileInfo->fileName[i];
+        fullFilename[i] = filePath[i];
     }
     ++fNamePos;
-    for (i = 0; i < j; ++i) filename[i] = fileInfo->fileName[i + fNamePos];
+    for (i = 0; i < j; ++i) filename[i] = filePath[i + fNamePos];
     filename[j]            = 0;
     fullFilename[fNamePos] = 0;
 

--- a/SonicCDDecomp/Reader.cpp
+++ b/SonicCDDecomp/Reader.cpp
@@ -284,7 +284,8 @@ size_t FileRead(void *dest, int size, File *file)
         if (Engine.usingDataFile) {
             while (size > 0) {
                 if (file->info.bufferPosition == file->readSize)
-                    FillFileBuffer(file);
+                    if (FillFileBuffer(file) == 0)
+                        break;
 
                 *data = encryptionStringB[file->info.eStringPosB] ^ file->info.eStringNo ^ file->fileBuffer[file->info.bufferPosition++];
                 if (file->info.eNybbleSwap)
@@ -323,7 +324,8 @@ size_t FileRead(void *dest, int size, File *file)
         else {
             while (size > 0) {
                 if (file->info.bufferPosition == file->readSize)
-                    FillFileBuffer(file);
+                    if (FillFileBuffer(file) == 0)
+                        break;
 
                 *data++ = file->fileBuffer[file->info.bufferPosition++];
                 size--;

--- a/SonicCDDecomp/Reader.cpp
+++ b/SonicCDDecomp/Reader.cpp
@@ -33,36 +33,23 @@ bool CheckRSDKFile(const char *filePath)
         Engine.usingDataFile = true;
         StrCopy(rsdkName, filePath);
         fClose(cFileHandle);
-        cFileHandle = NULL;
-        if (LoadFile("Data/Scripts/ByteCode/GlobalCode.bin", &info)) {
-            Engine.usingBytecode = true;
-            Engine.bytecodeMode  = BYTECODE_MOBILE;
-            CloseFile();
-        }
-        else if (LoadFile("Data/Scripts/ByteCode/GS000.bin", &info)) {
-            Engine.usingBytecode = true;
-            Engine.bytecodeMode  = BYTECODE_PC;
-            CloseFile();
-        }
-        return true;
     }
     else {
         Engine.usingDataFile = false;
-        cFileHandle = NULL;
-        if (LoadFile("Data/Scripts/ByteCode/GlobalCode.bin", &info)) {
-            Engine.usingBytecode = true;
-            Engine.bytecodeMode  = BYTECODE_MOBILE;
-            CloseFile();
-        }
-        else if (LoadFile("Data/Scripts/ByteCode/GS000.bin", &info)) {
-            Engine.usingBytecode = true;
-            Engine.bytecodeMode  = BYTECODE_PC;
-            CloseFile();
-        }
-        return false;
     }
 
-    return false;
+    cFileHandle = NULL;
+    if (LoadFile("Data/Scripts/ByteCode/GlobalCode.bin", &info)) {
+        Engine.usingBytecode = true;
+        Engine.bytecodeMode  = BYTECODE_MOBILE;
+        CloseFile();
+    }
+    else if (LoadFile("Data/Scripts/ByteCode/GS000.bin", &info)) {
+        Engine.usingBytecode = true;
+        Engine.bytecodeMode  = BYTECODE_PC;
+        CloseFile();
+    }
+    return Engine.usingDataFile;
 }
 
 bool LoadFile(const char *filePath, FileInfo *fileInfo)

--- a/SonicCDDecomp/Reader.cpp
+++ b/SonicCDDecomp/Reader.cpp
@@ -7,8 +7,8 @@ FileInfo globalFileInfo;
 byte fileBuffer[0x2000];
 int vFileSize;
 int readSize;
-char encryptionStringA[] = { "4RaS9D7KaEbxcp2o5r6t" };
-char encryptionStringB[] = { "3tRaUxLmEaSn" };
+static const char encryptionStringA[] = { "4RaS9D7KaEbxcp2o5r6t" };
+static const char encryptionStringB[] = { "3tRaUxLmEaSn" };
 
 FileIO *cFileHandle = nullptr;
 FileIO *cFileHandleStream = nullptr;

--- a/SonicCDDecomp/Reader.cpp
+++ b/SonicCDDecomp/Reader.cpp
@@ -10,8 +10,6 @@ File cFile;
 
 bool CheckRSDKFile(const char *filePath)
 {
-    FileInfo info;
-
     Engine.usingDataFile = false;
     Engine.usingBytecode = false;
 
@@ -26,12 +24,12 @@ bool CheckRSDKFile(const char *filePath)
     }
 
     cFile.handle = NULL;
-    if (LoadFile("Data/Scripts/ByteCode/GlobalCode.bin", &info)) {
+    if (LoadFile("Data/Scripts/ByteCode/GlobalCode.bin")) {
         Engine.usingBytecode = true;
         Engine.bytecodeMode  = BYTECODE_MOBILE;
         CloseFile();
     }
-    else if (LoadFile("Data/Scripts/ByteCode/GS000.bin", &info)) {
+    else if (LoadFile("Data/Scripts/ByteCode/GS000.bin")) {
         Engine.usingBytecode = true;
         Engine.bytecodeMode  = BYTECODE_PC;
         CloseFile();
@@ -39,10 +37,9 @@ bool CheckRSDKFile(const char *filePath)
     return Engine.usingDataFile;
 }
 
-bool LoadFile(const char *filePath, FileInfo *fileInfo, File *file)
+bool LoadFile(const char *filePath, File *file)
 {
-    MEM_ZEROP(fileInfo);
-    StrCopy(fileInfo->fileName, filePath);
+    MEM_ZERO(file->info);
     StrCopy(file->info.fileName, filePath);
 
     if (file->handle)
@@ -57,40 +54,25 @@ bool LoadFile(const char *filePath, FileInfo *fileInfo, File *file)
         file->info.bufferPosition = 0;
         file->readSize       = 0;
         file->info.readPos        = 0;
-        if (!ParseVirtualFileSystem(fileInfo->fileName, file)) {
+        if (!ParseVirtualFileSystem(filePath, file)) {
             fClose(file->handle);
             file->handle = NULL;
             printLog("Couldn't load file '%s'", filePath);
             return false;
         }
-        fileInfo->readPos           = file->info.readPos;
-        fileInfo->fileSize          = file->info.fileSize;
-        fileInfo->virtualFileOffset = file->info.virtualFileOffset;
-        fileInfo->eStringNo         = file->info.eStringNo;
-        fileInfo->eStringPosB       = file->info.eStringPosB;
-        fileInfo->eStringPosA       = file->info.eStringPosA;
-        fileInfo->eNybbleSwap       = file->info.eNybbleSwap;
-        fileInfo->bufferPosition    = file->info.bufferPosition;
     }
     else {
-        file->handle = fOpen(fileInfo->fileName, "rb");
+        file->handle = fOpen(filePath, "rb");
         if (!file->handle) {
             printLog("Couldn't load file '%s'", filePath);
             return false;
         }
         file->info.virtualFileOffset = 0;
         fSeek(file->handle, 0, SEEK_END);
-        fileInfo->fileSize = (int)fTell(file->handle);
-        file->actualFileSize           = fileInfo->fileSize;
+        file->info.fileSize = (int)fTell(file->handle);
+        file->actualFileSize           = file->info.fileSize;
         fSeek(file->handle, 0, SEEK_SET);
-        file->info.readPos = 0;
-        fileInfo->readPos           = file->info.readPos;
-        fileInfo->virtualFileOffset = 0;
-        fileInfo->eStringNo         = 0;
-        fileInfo->eStringPosB       = 0;
-        fileInfo->eStringPosA       = 0;
-        fileInfo->eNybbleSwap       = 0;
-        fileInfo->bufferPosition    = 0;
+        file->info.readPos           = 0;
     }
     file->info.bufferPosition = 0;
     file->readSize       = 0;

--- a/SonicCDDecomp/Reader.cpp
+++ b/SonicCDDecomp/Reader.cpp
@@ -277,12 +277,12 @@ bool ParseVirtualFileSystem(FileInfo *fileInfo, File *file)
 
 size_t FileRead(void *dest, int size, File *file)
 {
-    size_t result = 0;
+    size_t bytes_read = 0;
     byte *data = (byte *)dest;
 
     if (file->info.readPos <= file->info.fileSize) {
         if (Engine.usingDataFile) {
-            while (size > 0) {
+            while (bytes_read != size) {
                 if (file->info.bufferPosition == file->readSize)
                     if (FillFileBuffer(file) == 0)
                         break;
@@ -317,24 +317,22 @@ size_t FileRead(void *dest, int size, File *file)
                     }
                 }
                 ++data;
-                --size;
-                ++result;
+                ++bytes_read;
             }
         }
         else {
-            while (size > 0) {
+            while (bytes_read != size) {
                 if (file->info.bufferPosition == file->readSize)
                     if (FillFileBuffer(file) == 0)
                         break;
 
                 *data++ = file->fileBuffer[file->info.bufferPosition++];
-                size--;
-                ++result;
+                ++bytes_read;
             }
         }
     }
 
-    return result;
+    return bytes_read;
 }
 
 void SetFileInfo(FileInfo *fileInfo, File *file)

--- a/SonicCDDecomp/Reader.hpp
+++ b/SonicCDDecomp/Reader.hpp
@@ -85,7 +85,7 @@ inline bool CloseFile(File *file = &cFile)
 
 size_t FileRead(void *dest, int size, File *file = &cFile);
 
-bool ParseVirtualFileSystem(FileInfo *fileInfo, File *file = &cFile);
+bool ParseVirtualFileSystem(const char *filePath, File *file = &cFile);
 
 inline size_t FillFileBuffer(File *file = &cFile)
 {

--- a/SonicCDDecomp/Reader.hpp
+++ b/SonicCDDecomp/Reader.hpp
@@ -73,50 +73,50 @@ inline void CopyFilePath(char *dest, const char *src)
 }
 bool CheckRSDKFile(const char *filePath);
 
-bool LoadFile(const char *filePath, FileInfo *fileInfo);
-inline bool CloseFile()
+bool LoadFile(const char *filePath, FileInfo *fileInfo, File *file = &cFile);
+inline bool CloseFile(File *file = &cFile)
 {
     int result = 0;
-    if (cFile.handle)
-        result = fClose(cFile.handle);
+    if (file->handle)
+        result = fClose(file->handle);
 
-    cFile.handle = NULL;
+    file->handle = NULL;
     return result;
 }
 
-void FileRead(void *dest, int size);
+void FileRead(void *dest, int size, File *file = &cFile);
 
-bool ParseVirtualFileSystem(FileInfo *fileInfo);
+bool ParseVirtualFileSystem(FileInfo *fileInfo, File *file = &cFile);
 
-inline size_t FillFileBuffer()
+inline size_t FillFileBuffer(File *file = &cFile)
 {
-    if (cFile.info.readPos + sizeof(cFile.fileBuffer) <= cFile.info.fileSize)
-        cFile.readSize = sizeof(cFile.fileBuffer);
+    if (file->info.readPos + sizeof(file->fileBuffer) <= file->info.fileSize)
+        file->readSize = sizeof(file->fileBuffer);
     else 
-        cFile.readSize = cFile.info.fileSize - cFile.info.readPos;
+        file->readSize = file->info.fileSize - file->info.readPos;
 
-    size_t result = fRead(cFile.fileBuffer, 1u, cFile.readSize, cFile.handle);
-    cFile.info.readPos += cFile.readSize;
-    cFile.info.bufferPosition = 0;
+    size_t result = fRead(file->fileBuffer, 1u, file->readSize, file->handle);
+    file->info.readPos += file->readSize;
+    file->info.bufferPosition = 0;
     return result;
 }
 
-inline void GetFileInfo(FileInfo *fileInfo)
+inline void GetFileInfo(FileInfo *fileInfo, File *file = &cFile)
 {
-    StrCopy(fileInfo->fileName, cFile.info.fileName);
-    fileInfo->bufferPosition = cFile.info.bufferPosition;
-    fileInfo->readPos        = cFile.info.readPos - cFile.readSize;
-    fileInfo->fileSize       = cFile.info.fileSize;
-    fileInfo->virtualFileOffset = cFile.info.virtualFileOffset;
-    fileInfo->eStringPosA    = cFile.info.eStringPosA;
-    fileInfo->eStringPosB    = cFile.info.eStringPosB;
-    fileInfo->eStringNo      = cFile.info.eStringNo;
-    fileInfo->eNybbleSwap    = cFile.info.eNybbleSwap;
+    StrCopy(fileInfo->fileName, file->info.fileName);
+    fileInfo->bufferPosition = file->info.bufferPosition;
+    fileInfo->readPos        = file->info.readPos - file->readSize;
+    fileInfo->fileSize       = file->info.fileSize;
+    fileInfo->virtualFileOffset = file->info.virtualFileOffset;
+    fileInfo->eStringPosA    = file->info.eStringPosA;
+    fileInfo->eStringPosB    = file->info.eStringPosB;
+    fileInfo->eStringNo      = file->info.eStringNo;
+    fileInfo->eNybbleSwap    = file->info.eNybbleSwap;
 }
-void SetFileInfo(FileInfo *fileInfo);
-size_t GetFilePosition();
-void SetFilePosition(int newPos);
-bool ReachedEndOfFile();
+void SetFileInfo(FileInfo *fileInfo, File *file = &cFile);
+size_t GetFilePosition(File *file = &cFile);
+void SetFilePosition(int newPos, File *file = &cFile);
+bool ReachedEndOfFile(File *file = &cFile);
 
 
 size_t FileRead2(FileInfo *info, void *dest, int size); // For Music Streaming

--- a/SonicCDDecomp/Reader.hpp
+++ b/SonicCDDecomp/Reader.hpp
@@ -46,15 +46,18 @@ struct FileInfo {
     byte eNybbleSwap;
 };
 
+struct File {
+    FileIO *handle;
+    FileInfo info;
+    byte fileBuffer[0x2000];
+    int vFileSize;
+    int readSize;
+};
+
 extern char rsdkName[0x400];
 
-extern FileInfo globalFileInfo;
-extern byte fileBuffer[0x2000];
-extern int vFileSize;
-extern int readSize;
-
-extern FileIO *cFileHandle;
-extern FileIO *cFileHandleStream;
+extern File cFile;
+extern File cFileStream;
 
 inline void CopyFilePath(char *dest, const char *src)
 {
@@ -74,10 +77,10 @@ bool LoadFile(const char *filePath, FileInfo *fileInfo);
 inline bool CloseFile()
 {
     int result = 0;
-    if (cFileHandle)
-        result = fClose(cFileHandle);
+    if (cFile.handle)
+        result = fClose(cFile.handle);
 
-    cFileHandle = NULL;
+    cFile.handle = NULL;
     return result;
 }
 
@@ -87,28 +90,28 @@ bool ParseVirtualFileSystem(FileInfo *fileInfo);
 
 inline size_t FillFileBuffer()
 {
-    if (globalFileInfo.readPos + sizeof(fileBuffer) <= globalFileInfo.fileSize)
-        readSize = sizeof(fileBuffer);
+    if (cFile.info.readPos + sizeof(cFile.fileBuffer) <= cFile.info.fileSize)
+        cFile.readSize = sizeof(cFile.fileBuffer);
     else 
-        readSize = globalFileInfo.fileSize - globalFileInfo.readPos;
+        cFile.readSize = cFile.info.fileSize - cFile.info.readPos;
 
-    size_t result = fRead(fileBuffer, 1u, readSize, cFileHandle);
-    globalFileInfo.readPos += readSize;
-    globalFileInfo.bufferPosition = 0;
+    size_t result = fRead(cFile.fileBuffer, 1u, cFile.readSize, cFile.handle);
+    cFile.info.readPos += cFile.readSize;
+    cFile.info.bufferPosition = 0;
     return result;
 }
 
 inline void GetFileInfo(FileInfo *fileInfo)
 {
-    StrCopy(fileInfo->fileName, globalFileInfo.fileName);
-    fileInfo->bufferPosition = globalFileInfo.bufferPosition;
-    fileInfo->readPos        = globalFileInfo.readPos - readSize;
-    fileInfo->fileSize       = globalFileInfo.fileSize;
-    fileInfo->virtualFileOffset = globalFileInfo.virtualFileOffset;
-    fileInfo->eStringPosA    = globalFileInfo.eStringPosA;
-    fileInfo->eStringPosB    = globalFileInfo.eStringPosB;
-    fileInfo->eStringNo      = globalFileInfo.eStringNo;
-    fileInfo->eNybbleSwap    = globalFileInfo.eNybbleSwap;
+    StrCopy(fileInfo->fileName, cFile.info.fileName);
+    fileInfo->bufferPosition = cFile.info.bufferPosition;
+    fileInfo->readPos        = cFile.info.readPos - cFile.readSize;
+    fileInfo->fileSize       = cFile.info.fileSize;
+    fileInfo->virtualFileOffset = cFile.info.virtualFileOffset;
+    fileInfo->eStringPosA    = cFile.info.eStringPosA;
+    fileInfo->eStringPosB    = cFile.info.eStringPosB;
+    fileInfo->eStringNo      = cFile.info.eStringNo;
+    fileInfo->eNybbleSwap    = cFile.info.eNybbleSwap;
 }
 void SetFileInfo(FileInfo *fileInfo);
 size_t GetFilePosition();
@@ -120,10 +123,10 @@ size_t FileRead2(FileInfo *info, void *dest, int size); // For Music Streaming
 inline bool CloseFile2()
 {
     int result = 0;
-    if (cFileHandleStream)
-        result = fClose(cFileHandleStream);
+    if (cFileStream.handle)
+        result = fClose(cFileStream.handle);
 
-    cFileHandleStream = NULL;
+    cFileStream.handle = NULL;
     return result;
 }
 size_t GetFilePosition2(FileInfo *info);

--- a/SonicCDDecomp/Reader.hpp
+++ b/SonicCDDecomp/Reader.hpp
@@ -52,8 +52,6 @@ extern FileInfo globalFileInfo;
 extern byte fileBuffer[0x2000];
 extern int vFileSize;
 extern int readSize;
-extern char encryptionStringA[21];
-extern char encryptionStringB[13];
 
 extern FileIO *cFileHandle;
 extern FileIO *cFileHandleStream;

--- a/SonicCDDecomp/Reader.hpp
+++ b/SonicCDDecomp/Reader.hpp
@@ -89,8 +89,8 @@ bool ParseVirtualFileSystem(FileInfo *fileInfo);
 
 inline size_t FillFileBuffer()
 {
-    if (globalFileInfo.readPos + 0x2000 <= globalFileInfo.fileSize)
-        readSize = 0x2000;
+    if (globalFileInfo.readPos + sizeof(fileBuffer) <= globalFileInfo.fileSize)
+        readSize = sizeof(fileBuffer);
     else 
         readSize = globalFileInfo.fileSize - globalFileInfo.readPos;
 

--- a/SonicCDDecomp/Reader.hpp
+++ b/SonicCDDecomp/Reader.hpp
@@ -57,7 +57,6 @@ struct File {
 extern char rsdkName[0x400];
 
 extern File cFile;
-extern File cFileStream;
 
 inline void CopyFilePath(char *dest, const char *src)
 {
@@ -84,7 +83,7 @@ inline bool CloseFile(File *file = &cFile)
     return result;
 }
 
-void FileRead(void *dest, int size, File *file = &cFile);
+size_t FileRead(void *dest, int size, File *file = &cFile);
 
 bool ParseVirtualFileSystem(FileInfo *fileInfo, File *file = &cFile);
 
@@ -117,19 +116,5 @@ void SetFileInfo(FileInfo *fileInfo, File *file = &cFile);
 size_t GetFilePosition(File *file = &cFile);
 void SetFilePosition(int newPos, File *file = &cFile);
 bool ReachedEndOfFile(File *file = &cFile);
-
-
-size_t FileRead2(FileInfo *info, void *dest, int size); // For Music Streaming
-inline bool CloseFile2()
-{
-    int result = 0;
-    if (cFileStream.handle)
-        result = fClose(cFileStream.handle);
-
-    cFileStream.handle = NULL;
-    return result;
-}
-size_t GetFilePosition2(FileInfo *info);
-void SetFilePosition2(FileInfo *info, int newPos);
 
 #endif // !READER_H

--- a/SonicCDDecomp/Reader.hpp
+++ b/SonicCDDecomp/Reader.hpp
@@ -48,18 +48,10 @@ struct FileInfo {
 
 extern char rsdkName[0x400];
 
-extern char fileName[0x100];
+extern FileInfo globalFileInfo;
 extern byte fileBuffer[0x2000];
-extern int fileSize;
 extern int vFileSize;
-extern int readPos;
 extern int readSize;
-extern int bufferPosition;
-extern int virtualFileOffset;
-extern byte eStringPosA;
-extern byte eStringPosB;
-extern byte eStringNo;
-extern byte eNybbleSwap;
 extern char encryptionStringA[21];
 extern char encryptionStringB[13];
 
@@ -97,28 +89,28 @@ bool ParseVirtualFileSystem(FileInfo *fileInfo);
 
 inline size_t FillFileBuffer()
 {
-    if (readPos + 0x2000 <= fileSize)
+    if (globalFileInfo.readPos + 0x2000 <= globalFileInfo.fileSize)
         readSize = 0x2000;
     else 
-        readSize = fileSize - readPos;
+        readSize = globalFileInfo.fileSize - globalFileInfo.readPos;
 
     size_t result = fRead(fileBuffer, 1u, readSize, cFileHandle);
-    readPos += readSize;
-    bufferPosition = 0;
+    globalFileInfo.readPos += readSize;
+    globalFileInfo.bufferPosition = 0;
     return result;
 }
 
 inline void GetFileInfo(FileInfo *fileInfo)
 {
-    StrCopy(fileInfo->fileName, fileName);
-    fileInfo->bufferPosition = bufferPosition;
-    fileInfo->readPos        = readPos - readSize;
-    fileInfo->fileSize       = fileSize;
-    fileInfo->virtualFileOffset = virtualFileOffset;
-    fileInfo->eStringPosA    = eStringPosA;
-    fileInfo->eStringPosB    = eStringPosB;
-    fileInfo->eStringNo      = eStringNo;
-    fileInfo->eNybbleSwap    = eNybbleSwap;
+    StrCopy(fileInfo->fileName, globalFileInfo.fileName);
+    fileInfo->bufferPosition = globalFileInfo.bufferPosition;
+    fileInfo->readPos        = globalFileInfo.readPos - readSize;
+    fileInfo->fileSize       = globalFileInfo.fileSize;
+    fileInfo->virtualFileOffset = globalFileInfo.virtualFileOffset;
+    fileInfo->eStringPosA    = globalFileInfo.eStringPosA;
+    fileInfo->eStringPosB    = globalFileInfo.eStringPosB;
+    fileInfo->eStringNo      = globalFileInfo.eStringNo;
+    fileInfo->eNybbleSwap    = globalFileInfo.eNybbleSwap;
 }
 void SetFileInfo(FileInfo *fileInfo);
 size_t GetFilePosition();

--- a/SonicCDDecomp/Reader.hpp
+++ b/SonicCDDecomp/Reader.hpp
@@ -50,7 +50,7 @@ struct File {
     FileIO *handle;
     FileInfo info;
     byte fileBuffer[0x2000];
-    int vFileSize;
+    int actualFileSize;
     int readSize;
 };
 
@@ -89,10 +89,10 @@ bool ParseVirtualFileSystem(FileInfo *fileInfo, File *file = &cFile);
 
 inline size_t FillFileBuffer(File *file = &cFile)
 {
-    if (file->info.readPos + sizeof(file->fileBuffer) <= file->info.fileSize)
+    if (file->info.readPos + sizeof(file->fileBuffer) <= file->actualFileSize)
         file->readSize = sizeof(file->fileBuffer);
     else 
-        file->readSize = file->info.fileSize - file->info.readPos;
+        file->readSize = file->actualFileSize - file->info.readPos;
 
     size_t result = fRead(file->fileBuffer, 1u, file->readSize, file->handle);
     file->info.readPos += file->readSize;
@@ -105,7 +105,7 @@ inline void GetFileInfo(FileInfo *fileInfo, File *file = &cFile)
     StrCopy(fileInfo->fileName, file->info.fileName);
     fileInfo->bufferPosition = file->info.bufferPosition;
     fileInfo->readPos        = file->info.readPos - file->readSize;
-    fileInfo->fileSize       = file->info.fileSize;
+    fileInfo->fileSize       = file->actualFileSize;
     fileInfo->virtualFileOffset = file->info.virtualFileOffset;
     fileInfo->eStringPosA    = file->info.eStringPosA;
     fileInfo->eStringPosB    = file->info.eStringPosB;

--- a/SonicCDDecomp/Reader.hpp
+++ b/SonicCDDecomp/Reader.hpp
@@ -72,7 +72,7 @@ inline void CopyFilePath(char *dest, const char *src)
 }
 bool CheckRSDKFile(const char *filePath);
 
-bool LoadFile(const char *filePath, FileInfo *fileInfo, File *file = &cFile);
+bool LoadFile(const char *filePath, File *file = &cFile);
 inline bool CloseFile(File *file = &cFile)
 {
     int result = 0;

--- a/SonicCDDecomp/RetroEngine.cpp
+++ b/SonicCDDecomp/RetroEngine.cpp
@@ -361,12 +361,11 @@ void RetroEngine::Run()
 
 bool RetroEngine::LoadGameConfig(const char *filePath)
 {
-    FileInfo info;
     byte fileBuffer  = 0;
     byte fileBuffer2 = 0;
     char data[0x40];
 
-    if (LoadFile(filePath, &info)) {
+    if (LoadFile(filePath)) {
         FileRead(&fileBuffer, 1);
         FileRead(gameWindowText, fileBuffer);
         gameWindowText[fileBuffer] = 0;

--- a/SonicCDDecomp/RetroEngine.cpp
+++ b/SonicCDDecomp/RetroEngine.cpp
@@ -2,6 +2,9 @@
 #if RETRO_PLATFORM == RETRO_UWP
 #include <winrt/base.h>
 #include <winrt/Windows.Storage.h>
+#elif RETRO_PLATFORM == RETRO_WIIU
+#include <unistd.h>
+#include <whb/sdcard.h>
 #endif
 
 bool usingCWD        = false;
@@ -249,6 +252,19 @@ bool processEvents()
 
 void RetroEngine::Init()
 {
+#if RETRO_PLATFORM == RETRO_WIIU
+    // chdir into the SD card
+	if (!WHBMountSdCard())
+		return;
+
+    const char *sd_path = WHBGetSdCardMountPath();
+
+    if (sd_path == NULL)
+        return;
+
+    chdir(sd_path);
+#endif
+
     CalculateTrigAngles();
     GenerateBlendLookupTable();
 #if RETRO_PLATFORM == RETRO_UWP
@@ -356,6 +372,10 @@ void RetroEngine::Run()
 
 #if RETRO_USING_SDL2
     SDL_Quit();
+#endif
+
+#if RETRO_PLATFORM == RETRO_WIIU
+    WHBUnmountSdCard();
 #endif
 }
 

--- a/SonicCDDecomp/RetroEngine.hpp
+++ b/SonicCDDecomp/RetroEngine.hpp
@@ -30,6 +30,7 @@ typedef unsigned int uint;
 // Custom Platforms start here
 #define RETRO_VITA (7)
 #define RETRO_UWP  (8)
+#define RETRO_WIIU (9)
 
 // Platform types (Game manages platform-specific code such as HUD position using this rather than the above)
 #define RETRO_STANDARD (0)
@@ -60,6 +61,8 @@ typedef unsigned int uint;
 #endif
 #elif defined __vita__
 #define RETRO_PLATFORM (RETRO_VITA)
+#elif defined __WIIU__
+#define RETRO_PLATFORM (RETRO_WIIU)
 #else
 #define RETRO_PLATFORM (RETRO_WIN) // Default
 #endif
@@ -72,6 +75,10 @@ typedef unsigned int uint;
 #define BASE_PATH            ""
 #define DEFAULT_SCREEN_XSIZE 424
 #define DEFAULT_FULLSCREEN   false
+#elif RETRO_PLATFORM == RETRO_WIIU
+#define BASE_PATH            "SonicCD/" // 'chdir' will be used in combination with this (the SD card path is obtained at runtime).
+#define DEFAULT_SCREEN_XSIZE 400        // Steam assets don't work at 424x240, so use a safe default. If users want it, they can configure it themselves.
+#define DEFAULT_FULLSCREEN   true       // Wii U doesn't have a windowing system
 #else
 #define BASE_PATH            ""
 #define DEFAULT_SCREEN_XSIZE 424
@@ -79,7 +86,7 @@ typedef unsigned int uint;
 #endif
 
 #if RETRO_PLATFORM == RETRO_WIN || RETRO_PLATFORM == RETRO_OSX || RETRO_PLATFORM == RETRO_iOS || RETRO_PLATFORM == RETRO_VITA                        \
-    || RETRO_PLATFORM == RETRO_UWP
+    || RETRO_PLATFORM == RETRO_UWP || RETRO_PLATFORM == RETRO_WIIU
 #define RETRO_USING_SDL1 (0)
 #define RETRO_USING_SDL2 (1)
 #else // Since its an else & not an elif these platforms probably aren't supported yet
@@ -106,7 +113,7 @@ typedef unsigned int uint;
 #else
 
 // use *this* macro to determine what platform the game thinks its running on (since only the first 7 platforms are supported natively by scripts)
-#if RETRO_PLATFORM == RETRO_VITA
+#if RETRO_PLATFORM == RETRO_VITA || RETRO_PLATFORM == RETRO_WIIU
 #define RETRO_GAMEPLATFORMID (RETRO_WIN)
 #elif RETRO_PLATFORM == RETRO_UWP
 #define RETRO_GAMEPLATFORMID (UAP_GetRetroGamePlatformId())
@@ -198,6 +205,11 @@ enum RetroBytecodeFormat {
 #include <vorbis/vorbisfile.h>
 #include <theora/theora.h>
 #include <theoraplay.h>
+#elif RETRO_PLATFORM == RETRO_WIIU
+#include "SDL.h"
+#include <vorbis/vorbisfile.h>
+#include <theora/theora.h>
+#include "theoraplay.h"
 #endif
 
 extern bool usingCWD;

--- a/SonicCDDecomp/Scene.cpp
+++ b/SonicCDDecomp/Scene.cpp
@@ -253,7 +253,6 @@ void LoadStageFiles(void)
 {
     StopAllSfx();
     FileInfo infoStore;
-    FileInfo info;
     byte fileBuffer  = 0;
     byte fileBuffer2 = 0;
     int scriptID    = 1;
@@ -267,11 +266,11 @@ void LoadStageFiles(void)
         for (int i = SPRITESHEETS_MAX; i > 0; i--) RemoveGraphicsFile((char *)"", i - 1);
 
         bool loadGlobals = false;
-        if (LoadStageFile("StageConfig.bin", stageListPosition, &info)) {
+        if (LoadStageFile("StageConfig.bin", stageListPosition)) {
             FileRead(&loadGlobals, 1);
             CloseFile();
         }
-        if (loadGlobals && LoadFile("Data/Game/GameConfig.bin", &info)) {
+        if (loadGlobals && LoadFile("Data/Game/GameConfig.bin")) {
             FileRead(&fileBuffer, 1);
             FileRead(&strBuffer, fileBuffer);
             FileRead(&fileBuffer, 1);
@@ -311,7 +310,7 @@ void LoadStageFiles(void)
             CloseFile();
         }
 
-        if (LoadStageFile("StageConfig.bin", stageListPosition, &info)) {
+        if (LoadStageFile("StageConfig.bin", stageListPosition)) {
             FileRead(&fileBuffer, 1); // Load Globals
             for (int i = 96; i < 128; ++i) {
                 byte clr[3];
@@ -365,8 +364,7 @@ void LoadStageFiles(void)
             }
             CloseFile();
         }
-        FileInfo info;
-        if (LoadStageFile("16x16Tiles.gif", stageListPosition, &info)) {
+        if (LoadStageFile("16x16Tiles.gif", stageListPosition)) {
             CloseFile();
             LoadStageGIFFile(stageListPosition);
         }
@@ -416,7 +414,7 @@ void LoadStageFiles(void)
     yScrollA = (playerList[0].YPos >> 16) - SCREEN_SCROLL_UP;
     yScrollB                 = (playerList[0].YPos >> 16) - SCREEN_SCROLL_UP + SCREEN_YSIZE;
 }
-int LoadActFile(const char *ext, int stageID, FileInfo *info)
+int LoadActFile(const char *ext, int stageID)
 {
     char dest[0x40];
 
@@ -428,9 +426,9 @@ int LoadActFile(const char *ext, int stageID, FileInfo *info)
 
     ConvertStringToInteger(stageList[activeStageList][stageID].id, &actID);
 
-    return LoadFile(dest, info);
+    return LoadFile(dest);
 }
-int LoadStageFile(const char *filePath, int stageID, FileInfo *info)
+int LoadStageFile(const char *filePath, int stageID)
 {
     char dest[0x40];
 
@@ -438,12 +436,11 @@ int LoadStageFile(const char *filePath, int stageID, FileInfo *info)
     StrAdd(dest, stageList[activeStageList][stageID].folder);
     StrAdd(dest, "/");
     StrAdd(dest, filePath);
-    return LoadFile(dest, info);
+    return LoadFile(dest);
 }
 void LoadActLayout()
 {
-    FileInfo info;
-    if (LoadActFile(".bin", stageListPosition, &info)) {
+    if (LoadActFile(".bin", stageListPosition)) {
         byte length = 0;
         FileRead(&length, 1);
         titleCardWord2 = (byte)length;
@@ -537,8 +534,7 @@ void LoadStageBackground()
         vParallax.scrollPos[i] = 0;
     }
 
-    FileInfo info;
-    if (LoadStageFile("Backgrounds.bin", stageListPosition, &info)) {
+    if (LoadStageFile("Backgrounds.bin", stageListPosition)) {
         byte fileBuffer = 0;
         byte layerCount = 0;
         FileRead(&layerCount, 1);
@@ -631,10 +627,9 @@ void LoadStageBackground()
 }
 void LoadStageChunks()
 {
-    FileInfo info;
     byte entry[3];
 
-    if (LoadStageFile("128x128Tiles.bin", stageListPosition, &info)) {
+    if (LoadStageFile("128x128Tiles.bin", stageListPosition)) {
         for (int i = 0; i < CHUNKTILE_COUNT; ++i) {
             FileRead(&entry, 3);
             entry[0] -= (byte)((entry[0] >> 6) << 6);
@@ -656,8 +651,7 @@ void LoadStageChunks()
 }
 void LoadStageCollisions()
 {
-    FileInfo info;
-    if (LoadStageFile("CollisionMasks.bin", stageListPosition, &info)) {
+    if (LoadStageFile("CollisionMasks.bin", stageListPosition)) {
 
         byte fileBuffer = 0;
         int tileIndex  = 0;
@@ -826,8 +820,7 @@ void LoadStageCollisions()
 }
 void LoadStageGIFFile(int stageID)
 {
-    FileInfo info;
-    if (LoadStageFile("16x16Tiles.gif", stageID, &info)) {
+    if (LoadStageFile("16x16Tiles.gif", stageID)) {
         byte fileBuffer = 0;
         int fileBuffer2 = 0;
 
@@ -892,8 +885,7 @@ void LoadStageGIFFile(int stageID)
 }
 void LoadStageGFXFile(int stageID)
 {
-    FileInfo info;
-    if (LoadStageFile("16x16Tiles.gfx", stageID, &info)) {
+    if (LoadStageFile("16x16Tiles.gfx", stageID)) {
         byte fileBuffer = 0;
         FileRead(&fileBuffer, 1);
         int width = fileBuffer << 8;

--- a/SonicCDDecomp/Scene.hpp
+++ b/SonicCDDecomp/Scene.hpp
@@ -208,8 +208,8 @@ inline bool CheckCurrentStageFolder(int stage)
 }
 
 void LoadStageFiles();
-int LoadActFile(const char *ext, int stageID, FileInfo *info);
-int LoadStageFile(const char *filePath, int stageID, FileInfo *info);
+int LoadActFile(const char *ext, int stageID);
+int LoadStageFile(const char *filePath, int stageID);
 
 void LoadActLayout();
 void LoadStageBackground();

--- a/SonicCDDecomp/Script.cpp
+++ b/SonicCDDecomp/Script.cpp
@@ -1429,8 +1429,8 @@ void ParseScriptFile(char *scriptName, int scriptID)
     char scriptPath[0x40];
     StrCopy(scriptPath, "Data/Scripts/");
     StrAdd(scriptPath, scriptName);
-    FileInfo info;
-    if (LoadFile(scriptPath, &info)) {
+    if (LoadFile(scriptPath)) {
+        FileInfo info = cFile.info;
         objectScriptList[scriptID].mobile = true; // all parsed scripts will use the updated format, old format support is purely for pc bytecode
         int readMode                      = READMODE_NORMAL;
         int parseMode                     = PARSEMODE_SCOPELESS;
@@ -1669,8 +1669,7 @@ void LoadBytecode(int stageListID, int scriptID)
         }
     }
 
-    FileInfo info;
-    if (LoadFile(scriptPath, &info)) {
+    if (LoadFile(scriptPath)) {
         byte fileBuffer = 0;
         int *scrData   = &scriptData[scriptCodePos];
         FileRead(&fileBuffer, 1);

--- a/SonicCDDecomp/Script.cpp
+++ b/SonicCDDecomp/Script.cpp
@@ -1430,7 +1430,7 @@ void ParseScriptFile(char *scriptName, int scriptID)
     StrCopy(scriptPath, "Data/Scripts/");
     StrAdd(scriptPath, scriptName);
     if (LoadFile(scriptPath)) {
-        FileInfo info = cFile.info;
+        int readPos = cFile.info.readPos;
         objectScriptList[scriptID].mobile = true; // all parsed scripts will use the updated format, old format support is purely for pc bytecode
         int readMode                      = READMODE_NORMAL;
         int parseMode                     = PARSEMODE_SCOPELESS;
@@ -1590,7 +1590,7 @@ void ParseScriptFile(char *scriptName, int scriptID)
                                 ConvertIfWhileStatement(scriptText);
                                 if (ConvertSwitchStatement(scriptText)) {
                                     parseMode    = PARSEMODE_SWITCHREAD;
-                                    info.readPos = (int)GetFilePosition();
+                                    readPos = (int)GetFilePosition();
                                     switchDeep   = 0;
                                 }
                                 ConvertArithmaticSyntax(scriptText);
@@ -1626,7 +1626,7 @@ void ParseScriptFile(char *scriptName, int scriptID)
                         CheckCaseNumber(scriptText);
                     }
                     else {
-                        SetFilePosition(info.readPos);
+                        SetFilePosition(readPos);
                         parseMode  = PARSEMODE_FUNCTION;
                         int jPos   = jumpTableStack[jumpTableStackPos];
                         switchDeep = abs(jumpTableData[jPos + 1] - jumpTableData[jPos]) + 1;

--- a/SonicCDDecomp/Sprite.cpp
+++ b/SonicCDDecomp/Sprite.cpp
@@ -257,8 +257,7 @@ void RemoveGraphicsFile(const char *filePath, int sheetID)
 
 int LoadBMPFile(const char *filePath, byte sheetID)
 {
-    FileInfo info;
-    if (LoadFile(filePath, &info)) {
+    if (LoadFile(filePath)) {
         GFXSurface *surface = &gfxSurface[sheetID];
         StrCopy(surface->fileName, filePath);
 
@@ -283,7 +282,7 @@ int LoadBMPFile(const char *filePath, byte sheetID)
         FileRead(&fileBuffer, 1);
         surface->height += fileBuffer << 24;
 
-        SetFilePosition(info.fileSize - surface->height * surface->width);
+        SetFilePosition(cFile.info.fileSize - surface->height * surface->width);
         surface->dataPosition = gfxDataPosition;
         byte *gfxData         = &graphicData[surface->dataPosition + surface->width * (surface->height - 1)];
         for (int y = 0; y < surface->height; ++y) {
@@ -314,8 +313,7 @@ int LoadBMPFile(const char *filePath, byte sheetID)
 }
 int LoadGIFFile(const char *filePath, byte sheetID)
 {
-    FileInfo info;
-    if (LoadFile(filePath, &info)) {
+    if (LoadFile(filePath)) {
         GFXSurface *surface = &gfxSurface[sheetID];
         StrCopy(surface->fileName, filePath);
 
@@ -390,8 +388,7 @@ int LoadGIFFile(const char *filePath, byte sheetID)
 }
 int LoadGFXFile(const char *filePath, byte sheetID)
 {
-    FileInfo info;
-    if (LoadFile(filePath, &info)) {
+    if (LoadFile(filePath)) {
         GFXSurface *surface = &gfxSurface[sheetID];
         StrCopy(surface->fileName, filePath);
 
@@ -448,8 +445,7 @@ int LoadGFXFile(const char *filePath, byte sheetID)
 }
 int LoadRSVFile(const char *filePath, byte sheetID)
 {
-    FileInfo info;
-    if (LoadFile(filePath, &info)) {
+    if (LoadFile(filePath)) {
         GFXSurface *surface = &gfxSurface[sheetID];
         StrCopy(surface->fileName, filePath);
 
@@ -493,8 +489,7 @@ int LoadRSVFile(const char *filePath, byte sheetID)
 int LoadPVRFile(const char *filePath, byte sheetID)
 {
     // ONLY READS "PVRTC 2bpp RGB" PVR FILES
-    FileInfo info;
-    if (LoadFile(filePath, &info)) {
+    if (LoadFile(filePath)) {
         GFXSurface *surface = &gfxSurface[sheetID];
         StrCopy(surface->fileName, filePath);
 

--- a/SonicCDDecomp/Text.cpp
+++ b/SonicCDDecomp/Text.cpp
@@ -9,8 +9,7 @@ void LoadFontFile(const char *filePath)
 {
     byte fileBuffer = 0;
     int cnt        = 0;
-    FileInfo info;
-    if (LoadFile(filePath, &info)) {
+    if (LoadFile(filePath)) {
         while (!ReachedEndOfFile()) {
             FileRead(&fileBuffer, 1);
             fontCharacterList[cnt].id = fileBuffer;
@@ -85,9 +84,8 @@ void LoadFontFile(const char *filePath)
 void LoadTextFile(TextMenu *menu, const char *filePath, byte mapCode)
 {
     bool flag = false;
-    FileInfo info;
     byte fileBuffer = 0;
-    if (LoadFile(filePath, &info)) {
+    if (LoadFile(filePath)) {
         menu->textDataPos                     = 0;
         menu->rowCount                         = 0;
         menu->entryStart[menu->rowCount] = menu->textDataPos;
@@ -296,12 +294,11 @@ void EditTextMenuEntry(TextMenu *menu, const char *text, int rowID)
 }
 void LoadConfigListText(TextMenu *menu, int listNo)
 {
-    FileInfo info;
     char strBuf[0x100];
     byte fileBuffer = 0;
     byte count      = 0;
     byte strLen     = 0;
-    if (LoadFile("Data/Game/GameConfig.bin", &info)) {
+    if (LoadFile("Data/Game/GameConfig.bin")) {
         // Name
         FileRead(&strLen, 1);
         FileRead(&strBuf, strLen);

--- a/SonicCDDecomp/Userdata.cpp
+++ b/SonicCDDecomp/Userdata.cpp
@@ -87,7 +87,11 @@ void InitUserdata()
         ini.SetInteger("Dev", "StartingScene", Engine.startStage = 0);
         ini.SetInteger("Dev", "FastForwardSpeed", Engine.fastForwardSpeed = 8);
         ini.SetBool("Dev", "UseSteamDir", Engine.useSteamDir = true);
+#if RETRO_PLATFORM == RETRO_WIIU
+        ini.SetBool("Dev", "UseHQModes", Engine.useHQModes = false); // Laggy on Wii U
+#else
         ini.SetBool("Dev", "UseHQModes", Engine.useHQModes = true);
+#endif
 
         ini.SetInteger("Game", "Language", Engine.language = RETRO_EN);
         ini.SetInteger("Game", "OriginalControls", -1);

--- a/SonicCDDecomp/Userdata.cpp
+++ b/SonicCDDecomp/Userdata.cpp
@@ -79,124 +79,126 @@ void InitUserdata()
     sprintf(buffer, BASE_PATH"settings.ini");
 #endif
     FileIO *file = fOpen(buffer, "rb");
-    IniParser ini;
     if (!file) {
-        ini.SetBool("Dev", "DevMenu", Engine.devMenu = false);
-        ini.SetBool("Dev", "EngineDebugMode", engineDebugMode = false);
-        ini.SetInteger("Dev", "StartingCategory", Engine.startList = 0);
-        ini.SetInteger("Dev", "StartingScene", Engine.startStage = 0);
-        ini.SetInteger("Dev", "FastForwardSpeed", Engine.fastForwardSpeed = 8);
-        ini.SetBool("Dev", "UseSteamDir", Engine.useSteamDir = true);
+        IniParser *ini = new IniParser();
+        ini->SetBool("Dev", "DevMenu", Engine.devMenu = false);
+        ini->SetBool("Dev", "EngineDebugMode", engineDebugMode = false);
+        ini->SetInteger("Dev", "StartingCategory", Engine.startList = 0);
+        ini->SetInteger("Dev", "StartingScene", Engine.startStage = 0);
+        ini->SetInteger("Dev", "FastForwardSpeed", Engine.fastForwardSpeed = 8);
+        ini->SetBool("Dev", "UseSteamDir", Engine.useSteamDir = true);
 #if RETRO_PLATFORM == RETRO_WIIU
-        ini.SetBool("Dev", "UseHQModes", Engine.useHQModes = false); // Laggy on Wii U
+        ini->SetBool("Dev", "UseHQModes", Engine.useHQModes = false); // Laggy on Wii U
 #else
-        ini.SetBool("Dev", "UseHQModes", Engine.useHQModes = true);
+        ini->SetBool("Dev", "UseHQModes", Engine.useHQModes = true);
 #endif
 
-        ini.SetInteger("Game", "Language", Engine.language = RETRO_EN);
-        ini.SetInteger("Game", "OriginalControls", -1);
+        ini->SetInteger("Game", "Language", Engine.language = RETRO_EN);
+        ini->SetInteger("Game", "OriginalControls", -1);
 
-        ini.SetBool("Window", "FullScreen", Engine.startFullScreen = DEFAULT_FULLSCREEN);
-        ini.SetBool("Window", "Borderless", Engine.borderless = false);
-        ini.SetBool("Window", "VSync", Engine.vsync = false);
-        ini.SetBool("Window", "EnhancedScaling", Engine.enhancedScaling = true);
-        ini.SetInteger("Window", "WindowScale", Engine.windowScale = 2);
-        ini.SetInteger("Window", "ScreenWidth", SCREEN_XSIZE = DEFAULT_SCREEN_XSIZE);
-        ini.SetInteger("Window", "RefreshRate", Engine.refreshRate = 60);
+        ini->SetBool("Window", "FullScreen", Engine.startFullScreen = DEFAULT_FULLSCREEN);
+        ini->SetBool("Window", "Borderless", Engine.borderless = false);
+        ini->SetBool("Window", "VSync", Engine.vsync = false);
+        ini->SetBool("Window", "EnhancedScaling", Engine.enhancedScaling = true);
+        ini->SetInteger("Window", "WindowScale", Engine.windowScale = 2);
+        ini->SetInteger("Window", "ScreenWidth", SCREEN_XSIZE = DEFAULT_SCREEN_XSIZE);
+        ini->SetInteger("Window", "RefreshRate", Engine.refreshRate = 60);
 
-        ini.SetFloat("Audio", "BGMVolume", bgmVolume / (float)MAX_VOLUME);
-        ini.SetFloat("Audio", "SFXVolume", sfxVolume / (float)MAX_VOLUME);
+        ini->SetFloat("Audio", "BGMVolume", bgmVolume / (float)MAX_VOLUME);
+        ini->SetFloat("Audio", "SFXVolume", sfxVolume / (float)MAX_VOLUME);
 
 #if RETRO_USING_SDL2
-        ini.SetComment("Keyboard 1", "IK1Comment", "Keyboard Mappings for P1 (Based on: https://wiki.libsdl.org/SDL_Scancode)");
-        ini.SetInteger("Keyboard 1", "Up", inputDevice[INPUT_UP].keyMappings = SDL_SCANCODE_UP);
-        ini.SetInteger("Keyboard 1", "Down", inputDevice[INPUT_DOWN].keyMappings = SDL_SCANCODE_DOWN);
-        ini.SetInteger("Keyboard 1", "Left", inputDevice[INPUT_LEFT].keyMappings = SDL_SCANCODE_LEFT);
-        ini.SetInteger("Keyboard 1", "Right", inputDevice[INPUT_RIGHT].keyMappings = SDL_SCANCODE_RIGHT);
-        ini.SetInteger("Keyboard 1", "A", inputDevice[INPUT_BUTTONA].keyMappings = SDL_SCANCODE_Z);
-        ini.SetInteger("Keyboard 1", "B", inputDevice[INPUT_BUTTONB].keyMappings = SDL_SCANCODE_X);
-        ini.SetInteger("Keyboard 1", "C", inputDevice[INPUT_BUTTONC].keyMappings = SDL_SCANCODE_C);
-        ini.SetInteger("Keyboard 1", "Start", inputDevice[INPUT_START].keyMappings = SDL_SCANCODE_RETURN);
+        ini->SetComment("Keyboard 1", "IK1Comment", "Keyboard Mappings for P1 (Based on: https://wiki.libsdl.org/SDL_Scancode)");
+        ini->SetInteger("Keyboard 1", "Up", inputDevice[INPUT_UP].keyMappings = SDL_SCANCODE_UP);
+        ini->SetInteger("Keyboard 1", "Down", inputDevice[INPUT_DOWN].keyMappings = SDL_SCANCODE_DOWN);
+        ini->SetInteger("Keyboard 1", "Left", inputDevice[INPUT_LEFT].keyMappings = SDL_SCANCODE_LEFT);
+        ini->SetInteger("Keyboard 1", "Right", inputDevice[INPUT_RIGHT].keyMappings = SDL_SCANCODE_RIGHT);
+        ini->SetInteger("Keyboard 1", "A", inputDevice[INPUT_BUTTONA].keyMappings = SDL_SCANCODE_Z);
+        ini->SetInteger("Keyboard 1", "B", inputDevice[INPUT_BUTTONB].keyMappings = SDL_SCANCODE_X);
+        ini->SetInteger("Keyboard 1", "C", inputDevice[INPUT_BUTTONC].keyMappings = SDL_SCANCODE_C);
+        ini->SetInteger("Keyboard 1", "Start", inputDevice[INPUT_START].keyMappings = SDL_SCANCODE_RETURN);
 
-        ini.SetComment("Controller 1", "IC1Comment", "Controller Mappings for P1 (Based on: https://wiki.libsdl.org/SDL_GameControllerButton)");
-        ini.SetInteger("Controller 1", "Up", inputDevice[INPUT_UP].contMappings = SDL_CONTROLLER_BUTTON_DPAD_UP);
-        ini.SetInteger("Controller 1", "Down", inputDevice[INPUT_DOWN].contMappings = SDL_CONTROLLER_BUTTON_DPAD_DOWN);
-        ini.SetInteger("Controller 1", "Left", inputDevice[INPUT_LEFT].contMappings = SDL_CONTROLLER_BUTTON_DPAD_LEFT);
-        ini.SetInteger("Controller 1", "Right", inputDevice[INPUT_RIGHT].contMappings = SDL_CONTROLLER_BUTTON_DPAD_RIGHT);
-        ini.SetInteger("Controller 1", "A", inputDevice[INPUT_BUTTONA].contMappings = SDL_CONTROLLER_BUTTON_A);
-        ini.SetInteger("Controller 1", "B", inputDevice[INPUT_BUTTONB].contMappings = SDL_CONTROLLER_BUTTON_B);
-        ini.SetInteger("Controller 1", "C", inputDevice[INPUT_BUTTONC].contMappings = SDL_CONTROLLER_BUTTON_X);
-        ini.SetInteger("Controller 1", "Start", inputDevice[INPUT_START].contMappings = SDL_CONTROLLER_BUTTON_START);
+        ini->SetComment("Controller 1", "IC1Comment", "Controller Mappings for P1 (Based on: https://wiki.libsdl.org/SDL_GameControllerButton)");
+        ini->SetInteger("Controller 1", "Up", inputDevice[INPUT_UP].contMappings = SDL_CONTROLLER_BUTTON_DPAD_UP);
+        ini->SetInteger("Controller 1", "Down", inputDevice[INPUT_DOWN].contMappings = SDL_CONTROLLER_BUTTON_DPAD_DOWN);
+        ini->SetInteger("Controller 1", "Left", inputDevice[INPUT_LEFT].contMappings = SDL_CONTROLLER_BUTTON_DPAD_LEFT);
+        ini->SetInteger("Controller 1", "Right", inputDevice[INPUT_RIGHT].contMappings = SDL_CONTROLLER_BUTTON_DPAD_RIGHT);
+        ini->SetInteger("Controller 1", "A", inputDevice[INPUT_BUTTONA].contMappings = SDL_CONTROLLER_BUTTON_A);
+        ini->SetInteger("Controller 1", "B", inputDevice[INPUT_BUTTONB].contMappings = SDL_CONTROLLER_BUTTON_B);
+        ini->SetInteger("Controller 1", "C", inputDevice[INPUT_BUTTONC].contMappings = SDL_CONTROLLER_BUTTON_X);
+        ini->SetInteger("Controller 1", "Start", inputDevice[INPUT_START].contMappings = SDL_CONTROLLER_BUTTON_START);
 #endif
 
 #if RETRO_USING_SDL1
-        ini.SetComment("Keyboard 1", "IK1Comment", "Keyboard Mappings for P1 (Based on: https://wiki.libsdl.org/SDL_Scancode)");
-        ini.SetInteger("Keyboard 1", "Up", inputDevice[INPUT_UP].keyMappings = SDLK_UP);
-        ini.SetInteger("Keyboard 1", "Down", inputDevice[INPUT_DOWN].keyMappings = SDLK_DOWN);
-        ini.SetInteger("Keyboard 1", "Left", inputDevice[INPUT_LEFT].keyMappings = SDLK_LEFT);
-        ini.SetInteger("Keyboard 1", "Right", inputDevice[INPUT_RIGHT].keyMappings = SDLK_RIGHT);
-        ini.SetInteger("Keyboard 1", "A", inputDevice[INPUT_BUTTONA].keyMappings = SDLK_z);
-        ini.SetInteger("Keyboard 1", "B", inputDevice[INPUT_BUTTONB].keyMappings = SDLK_x);
-        ini.SetInteger("Keyboard 1", "C", inputDevice[INPUT_BUTTONC].keyMappings = SDLK_c);
-        ini.SetInteger("Keyboard 1", "Start", inputDevice[INPUT_START].keyMappings = SDLK_RETURN);
+        ini->SetComment("Keyboard 1", "IK1Comment", "Keyboard Mappings for P1 (Based on: https://wiki.libsdl.org/SDL_Scancode)");
+        ini->SetInteger("Keyboard 1", "Up", inputDevice[INPUT_UP].keyMappings = SDLK_UP);
+        ini->SetInteger("Keyboard 1", "Down", inputDevice[INPUT_DOWN].keyMappings = SDLK_DOWN);
+        ini->SetInteger("Keyboard 1", "Left", inputDevice[INPUT_LEFT].keyMappings = SDLK_LEFT);
+        ini->SetInteger("Keyboard 1", "Right", inputDevice[INPUT_RIGHT].keyMappings = SDLK_RIGHT);
+        ini->SetInteger("Keyboard 1", "A", inputDevice[INPUT_BUTTONA].keyMappings = SDLK_z);
+        ini->SetInteger("Keyboard 1", "B", inputDevice[INPUT_BUTTONB].keyMappings = SDLK_x);
+        ini->SetInteger("Keyboard 1", "C", inputDevice[INPUT_BUTTONC].keyMappings = SDLK_c);
+        ini->SetInteger("Keyboard 1", "Start", inputDevice[INPUT_START].keyMappings = SDLK_RETURN);
 
-        ini.SetComment("Controller 1", "IC1Comment", "Controller Mappings for P1 (Based on: https://wiki.libsdl.org/SDL_GameControllerButton)");
-        ini.SetInteger("Controller 1", "Up", inputDevice[INPUT_UP].contMappings = 1);
-        ini.SetInteger("Controller 1", "Down", inputDevice[INPUT_DOWN].contMappings = 2);
-        ini.SetInteger("Controller 1", "Left", inputDevice[INPUT_LEFT].contMappings = 3);
-        ini.SetInteger("Controller 1", "Right", inputDevice[INPUT_RIGHT].contMappings = 4);
-        ini.SetInteger("Controller 1", "A", inputDevice[INPUT_BUTTONA].contMappings = 5);
-        ini.SetInteger("Controller 1", "B", inputDevice[INPUT_BUTTONB].contMappings = 6);
-        ini.SetInteger("Controller 1", "C", inputDevice[INPUT_BUTTONC].contMappings = 7);
-        ini.SetInteger("Controller 1", "Start", inputDevice[INPUT_START].contMappings = 8);
+        ini->SetComment("Controller 1", "IC1Comment", "Controller Mappings for P1 (Based on: https://wiki.libsdl.org/SDL_GameControllerButton)");
+        ini->SetInteger("Controller 1", "Up", inputDevice[INPUT_UP].contMappings = 1);
+        ini->SetInteger("Controller 1", "Down", inputDevice[INPUT_DOWN].contMappings = 2);
+        ini->SetInteger("Controller 1", "Left", inputDevice[INPUT_LEFT].contMappings = 3);
+        ini->SetInteger("Controller 1", "Right", inputDevice[INPUT_RIGHT].contMappings = 4);
+        ini->SetInteger("Controller 1", "A", inputDevice[INPUT_BUTTONA].contMappings = 5);
+        ini->SetInteger("Controller 1", "B", inputDevice[INPUT_BUTTONB].contMappings = 6);
+        ini->SetInteger("Controller 1", "C", inputDevice[INPUT_BUTTONC].contMappings = 7);
+        ini->SetInteger("Controller 1", "Start", inputDevice[INPUT_START].contMappings = 8);
 #endif
 
-        ini.Write(BASE_PATH"settings.ini");
+        ini->Write(BASE_PATH"settings.ini");
+
+        delete ini;
     }
     else {
         fClose(file);
-        ini = IniParser(BASE_PATH"settings.ini");
+        IniParser *ini = new IniParser(BASE_PATH"settings.ini");
 
-        if (!ini.GetBool("Dev", "DevMenu", &Engine.devMenu))
+        if (!ini->GetBool("Dev", "DevMenu", &Engine.devMenu))
             Engine.devMenu = false;
-        if (!ini.GetBool("Dev", "EngineDebugMode", &engineDebugMode))
+        if (!ini->GetBool("Dev", "EngineDebugMode", &engineDebugMode))
             engineDebugMode = false;
-        if (!ini.GetInteger("Dev", "StartingCategory", &Engine.startList))
+        if (!ini->GetInteger("Dev", "StartingCategory", &Engine.startList))
             Engine.startList = 0;
-        if (!ini.GetInteger("Dev", "StartingScene", &Engine.startStage))
+        if (!ini->GetInteger("Dev", "StartingScene", &Engine.startStage))
             Engine.startStage = 0;
-        if (!ini.GetInteger("Dev", "FastForwardSpeed", &Engine.fastForwardSpeed))
+        if (!ini->GetInteger("Dev", "FastForwardSpeed", &Engine.fastForwardSpeed))
             Engine.fastForwardSpeed = 8;
-        if (!ini.GetBool("Dev", "UseSteamDir", &Engine.useSteamDir))
+        if (!ini->GetBool("Dev", "UseSteamDir", &Engine.useSteamDir))
             Engine.useSteamDir = true;
-        if (!ini.GetBool("Dev", "UseHQModes", &Engine.useHQModes))
+        if (!ini->GetBool("Dev", "UseHQModes", &Engine.useHQModes))
             Engine.useHQModes = true;
 
-        if (!ini.GetInteger("Game", "Language", &Engine.language))
+        if (!ini->GetInteger("Game", "Language", &Engine.language))
             Engine.language = RETRO_EN;
         
-        if (!ini.GetInteger("Game", "OriginalControls", &controlMode))
+        if (!ini->GetInteger("Game", "OriginalControls", &controlMode))
             controlMode = -1;
 
-        if (!ini.GetBool("Window", "FullScreen", &Engine.startFullScreen))
+        if (!ini->GetBool("Window", "FullScreen", &Engine.startFullScreen))
             Engine.startFullScreen = DEFAULT_FULLSCREEN;
-        if (!ini.GetBool("Window", "Borderless", &Engine.borderless))
+        if (!ini->GetBool("Window", "Borderless", &Engine.borderless))
             Engine.borderless = false;
-        if (!ini.GetBool("Window", "VSync", &Engine.vsync))
+        if (!ini->GetBool("Window", "VSync", &Engine.vsync))
             Engine.vsync = false;
-        if (!ini.GetBool("Window", "EnhancedScaling", &Engine.enhancedScaling))
+        if (!ini->GetBool("Window", "EnhancedScaling", &Engine.enhancedScaling))
             Engine.enhancedScaling = true;
-        if (!ini.GetInteger("Window", "WindowScale", &Engine.windowScale))
+        if (!ini->GetInteger("Window", "WindowScale", &Engine.windowScale))
             Engine.windowScale = 2;
-        if (!ini.GetInteger("Window", "ScreenWidth", &SCREEN_XSIZE))
+        if (!ini->GetInteger("Window", "ScreenWidth", &SCREEN_XSIZE))
             SCREEN_XSIZE = DEFAULT_SCREEN_XSIZE;
-        if (!ini.GetInteger("Window", "RefreshRate", &Engine.refreshRate))
+        if (!ini->GetInteger("Window", "RefreshRate", &Engine.refreshRate))
             Engine.refreshRate = 60;
 
         float bv = 0, sv = 0;
-        if (!ini.GetFloat("Audio", "BGMVolume", &bv))
+        if (!ini->GetFloat("Audio", "BGMVolume", &bv))
             bv = 1.0f;
-        if (!ini.GetFloat("Audio", "SFXVolume", &sv))
+        if (!ini->GetFloat("Audio", "SFXVolume", &sv))
             sv = 1.0f;
 
         bgmVolume = bv * MAX_VOLUME;
@@ -213,76 +215,78 @@ void InitUserdata()
             sfxVolume = 0;
 
 #if RETRO_USING_SDL2
-        if (!ini.GetInteger("Keyboard 1", "Up", &inputDevice[INPUT_UP].keyMappings))
+        if (!ini->GetInteger("Keyboard 1", "Up", &inputDevice[INPUT_UP].keyMappings))
             inputDevice[0].keyMappings = SDL_SCANCODE_UP;
-        if (!ini.GetInteger("Keyboard 1", "Down", &inputDevice[INPUT_DOWN].keyMappings))
+        if (!ini->GetInteger("Keyboard 1", "Down", &inputDevice[INPUT_DOWN].keyMappings))
             inputDevice[1].keyMappings = SDL_SCANCODE_DOWN;
-        if (!ini.GetInteger("Keyboard 1", "Left", &inputDevice[INPUT_LEFT].keyMappings))
+        if (!ini->GetInteger("Keyboard 1", "Left", &inputDevice[INPUT_LEFT].keyMappings))
             inputDevice[2].keyMappings = SDL_SCANCODE_LEFT;
-        if (!ini.GetInteger("Keyboard 1", "Right", &inputDevice[INPUT_RIGHT].keyMappings))
+        if (!ini->GetInteger("Keyboard 1", "Right", &inputDevice[INPUT_RIGHT].keyMappings))
             inputDevice[3].keyMappings = SDL_SCANCODE_RIGHT;
-        if (!ini.GetInteger("Keyboard 1", "A", &inputDevice[INPUT_BUTTONA].keyMappings))
+        if (!ini->GetInteger("Keyboard 1", "A", &inputDevice[INPUT_BUTTONA].keyMappings))
             inputDevice[4].keyMappings = SDL_SCANCODE_Z;
-        if (!ini.GetInteger("Keyboard 1", "B", &inputDevice[INPUT_BUTTONB].keyMappings))
+        if (!ini->GetInteger("Keyboard 1", "B", &inputDevice[INPUT_BUTTONB].keyMappings))
             inputDevice[5].keyMappings = SDL_SCANCODE_X;
-        if (!ini.GetInteger("Keyboard 1", "C", &inputDevice[INPUT_BUTTONC].keyMappings))
+        if (!ini->GetInteger("Keyboard 1", "C", &inputDevice[INPUT_BUTTONC].keyMappings))
             inputDevice[6].keyMappings = SDL_SCANCODE_C;
-        if (!ini.GetInteger("Keyboard 1", "Start", &inputDevice[INPUT_START].keyMappings))
+        if (!ini->GetInteger("Keyboard 1", "Start", &inputDevice[INPUT_START].keyMappings))
             inputDevice[7].keyMappings = SDL_SCANCODE_RETURN;
 
-        if (!ini.GetInteger("Controller 1", "Up", &inputDevice[INPUT_UP].contMappings))
+        if (!ini->GetInteger("Controller 1", "Up", &inputDevice[INPUT_UP].contMappings))
             inputDevice[0].contMappings = SDL_CONTROLLER_BUTTON_DPAD_UP;
-        if (!ini.GetInteger("Controller 1", "Down", &inputDevice[INPUT_DOWN].contMappings))
+        if (!ini->GetInteger("Controller 1", "Down", &inputDevice[INPUT_DOWN].contMappings))
             inputDevice[1].contMappings = SDL_CONTROLLER_BUTTON_DPAD_DOWN;
-        if (!ini.GetInteger("Controller 1", "Left", &inputDevice[INPUT_LEFT].contMappings))
+        if (!ini->GetInteger("Controller 1", "Left", &inputDevice[INPUT_LEFT].contMappings))
             inputDevice[2].contMappings = SDL_CONTROLLER_BUTTON_DPAD_LEFT;
-        if (!ini.GetInteger("Controller 1", "Right", &inputDevice[INPUT_RIGHT].contMappings))
+        if (!ini->GetInteger("Controller 1", "Right", &inputDevice[INPUT_RIGHT].contMappings))
             inputDevice[3].contMappings = SDL_CONTROLLER_BUTTON_DPAD_RIGHT;
-        if (!ini.GetInteger("Controller 1", "A", &inputDevice[INPUT_BUTTONA].contMappings))
+        if (!ini->GetInteger("Controller 1", "A", &inputDevice[INPUT_BUTTONA].contMappings))
             inputDevice[4].contMappings = SDL_CONTROLLER_BUTTON_A;
-        if (!ini.GetInteger("Controller 1", "B", &inputDevice[INPUT_BUTTONB].contMappings))
+        if (!ini->GetInteger("Controller 1", "B", &inputDevice[INPUT_BUTTONB].contMappings))
             inputDevice[5].contMappings = SDL_CONTROLLER_BUTTON_B;
-        if (!ini.GetInteger("Controller 1", "C", &inputDevice[INPUT_BUTTONC].contMappings))
+        if (!ini->GetInteger("Controller 1", "C", &inputDevice[INPUT_BUTTONC].contMappings))
             inputDevice[6].contMappings = SDL_CONTROLLER_BUTTON_X;
-        if (!ini.GetInteger("Controller 1", "Start", &inputDevice[INPUT_START].contMappings))
+        if (!ini->GetInteger("Controller 1", "Start", &inputDevice[INPUT_START].contMappings))
             inputDevice[7].contMappings = SDL_CONTROLLER_BUTTON_START;
 #endif
 
 #if RETRO_USING_SDL1
-        if (!ini.GetInteger("Keyboard 1", "Up", &inputDevice[INPUT_UP].keyMappings))
+        if (!ini->GetInteger("Keyboard 1", "Up", &inputDevice[INPUT_UP].keyMappings))
             inputDevice[0].keyMappings = SDLK_UP;
-        if (!ini.GetInteger("Keyboard 1", "Down", &inputDevice[INPUT_DOWN].keyMappings))
+        if (!ini->GetInteger("Keyboard 1", "Down", &inputDevice[INPUT_DOWN].keyMappings))
             inputDevice[1].keyMappings = SDLK_DOWN;
-        if (!ini.GetInteger("Keyboard 1", "Left", &inputDevice[INPUT_LEFT].keyMappings))
+        if (!ini->GetInteger("Keyboard 1", "Left", &inputDevice[INPUT_LEFT].keyMappings))
             inputDevice[2].keyMappings = SDLK_LEFT;
-        if (!ini.GetInteger("Keyboard 1", "Right", &inputDevice[INPUT_RIGHT].keyMappings))
+        if (!ini->GetInteger("Keyboard 1", "Right", &inputDevice[INPUT_RIGHT].keyMappings))
             inputDevice[3].keyMappings = SDLK_RIGHT;
-        if (!ini.GetInteger("Keyboard 1", "A", &inputDevice[INPUT_BUTTONA].keyMappings))
+        if (!ini->GetInteger("Keyboard 1", "A", &inputDevice[INPUT_BUTTONA].keyMappings))
             inputDevice[4].keyMappings = SDLK_z;
-        if (!ini.GetInteger("Keyboard 1", "B", &inputDevice[INPUT_BUTTONB].keyMappings))
+        if (!ini->GetInteger("Keyboard 1", "B", &inputDevice[INPUT_BUTTONB].keyMappings))
             inputDevice[5].keyMappings = SDLK_x;
-        if (!ini.GetInteger("Keyboard 1", "C", &inputDevice[INPUT_BUTTONC].keyMappings))
+        if (!ini->GetInteger("Keyboard 1", "C", &inputDevice[INPUT_BUTTONC].keyMappings))
             inputDevice[6].keyMappings = SDLK_c;
-        if (!ini.GetInteger("Keyboard 1", "Start", &inputDevice[INPUT_START].keyMappings))
+        if (!ini->GetInteger("Keyboard 1", "Start", &inputDevice[INPUT_START].keyMappings))
             inputDevice[7].keyMappings = SDLK_RETURN;
 
-        if (!ini.GetInteger("Controller 1", "Up", &inputDevice[INPUT_UP].contMappings))
+        if (!ini->GetInteger("Controller 1", "Up", &inputDevice[INPUT_UP].contMappings))
             inputDevice[0].contMappings = 1;
-        if (!ini.GetInteger("Controller 1", "Down", &inputDevice[INPUT_DOWN].contMappings))
+        if (!ini->GetInteger("Controller 1", "Down", &inputDevice[INPUT_DOWN].contMappings))
             inputDevice[1].contMappings = 2;
-        if (!ini.GetInteger("Controller 1", "Left", &inputDevice[INPUT_LEFT].contMappings))
+        if (!ini->GetInteger("Controller 1", "Left", &inputDevice[INPUT_LEFT].contMappings))
             inputDevice[2].contMappings = 3;
-        if (!ini.GetInteger("Controller 1", "Right", &inputDevice[INPUT_RIGHT].contMappings))
+        if (!ini->GetInteger("Controller 1", "Right", &inputDevice[INPUT_RIGHT].contMappings))
             inputDevice[3].contMappings = 4;
-        if (!ini.GetInteger("Controller 1", "A", &inputDevice[INPUT_BUTTONA].contMappings))
+        if (!ini->GetInteger("Controller 1", "A", &inputDevice[INPUT_BUTTONA].contMappings))
             inputDevice[4].contMappings = 5;
-        if (!ini.GetInteger("Controller 1", "B", &inputDevice[INPUT_BUTTONB].contMappings))
+        if (!ini->GetInteger("Controller 1", "B", &inputDevice[INPUT_BUTTONB].contMappings))
             inputDevice[5].contMappings = 6;
-        if (!ini.GetInteger("Controller 1", "C", &inputDevice[INPUT_BUTTONC].contMappings))
+        if (!ini->GetInteger("Controller 1", "C", &inputDevice[INPUT_BUTTONC].contMappings))
             inputDevice[6].contMappings = 7;
-        if (!ini.GetInteger("Controller 1", "Start", &inputDevice[INPUT_START].contMappings))
+        if (!ini->GetInteger("Controller 1", "Start", &inputDevice[INPUT_START].contMappings))
             inputDevice[7].contMappings = 8;
 #endif
+
+        delete ini;
     }
     SetScreenSize(SCREEN_XSIZE, SCREEN_YSIZE);
 
@@ -401,86 +405,88 @@ void InitUserdata()
 }
 
 void writeSettings() {
-    IniParser ini;
+    IniParser *ini = new IniParser();
 
-    ini.SetComment("Dev", "DevMenuComment", "Enable this flag to activate dev menu via the ESC key");
-    ini.SetBool("Dev", "DevMenu", Engine.devMenu);
-    ini.SetComment("Dev", "DebugModeComment", "Enable this flag to activate features used for debugging the engine (may result in slightly slower game speed)");
-    ini.SetBool("Dev", "EngineDebugMode", engineDebugMode);
-    ini.SetComment("Dev", "SCComment", "Sets the starting category ID");
-    ini.SetInteger("Dev", "StartingCategory", Engine.startList);
-    ini.SetComment("Dev", "SSComment", "Sets the starting scene ID");
-    ini.SetInteger("Dev", "StartingScene", Engine.startStage);
-    ini.SetComment("Dev", "FFComment", "Determines how fast the game will be when fastforwarding is active");
-    ini.SetInteger("Dev", "FastForwardSpeed", Engine.fastForwardSpeed);
-    ini.SetComment("Dev", "SDComment", "Determines if the game will try to use the steam directory for the game if it can locate it (windows only)");
-    ini.SetBool("Dev", "UseSteamDir", Engine.useSteamDir);
-    ini.SetComment("Dev", "UseHQComment","Determines if applicable rendering modes (such as 3D floor from special stages) will render in \"High Quality\" mode or standard mode");
-    ini.SetBool("Dev", "UseHQModes", Engine.useHQModes);
+    ini->SetComment("Dev", "DevMenuComment", "Enable this flag to activate dev menu via the ESC key");
+    ini->SetBool("Dev", "DevMenu", Engine.devMenu);
+    ini->SetComment("Dev", "DebugModeComment", "Enable this flag to activate features used for debugging the engine (may result in slightly slower game speed)");
+    ini->SetBool("Dev", "EngineDebugMode", engineDebugMode);
+    ini->SetComment("Dev", "SCComment", "Sets the starting category ID");
+    ini->SetInteger("Dev", "StartingCategory", Engine.startList);
+    ini->SetComment("Dev", "SSComment", "Sets the starting scene ID");
+    ini->SetInteger("Dev", "StartingScene", Engine.startStage);
+    ini->SetComment("Dev", "FFComment", "Determines how fast the game will be when fastforwarding is active");
+    ini->SetInteger("Dev", "FastForwardSpeed", Engine.fastForwardSpeed);
+    ini->SetComment("Dev", "SDComment", "Determines if the game will try to use the steam directory for the game if it can locate it (windows only)");
+    ini->SetBool("Dev", "UseSteamDir", Engine.useSteamDir);
+    ini->SetComment("Dev", "UseHQComment","Determines if applicable rendering modes (such as 3D floor from special stages) will render in \"High Quality\" mode or standard mode");
+    ini->SetBool("Dev", "UseHQModes", Engine.useHQModes);
 
-    ini.SetComment("Game", "LangComment", "Sets the game language (0 = EN, 1 = FR, 2 = IT, 3 = DE, 4 = ES, 5 = JP)");
-    ini.SetInteger("Game", "Language", Engine.language);
-    ini.SetComment("Game", "OGCtrlComment", "Sets the game's spindash style (-1 = let save file decide, 0 = S2, 1 = CD)");
-    ini.SetInteger("Game", "OriginalControls", controlMode);
+    ini->SetComment("Game", "LangComment", "Sets the game language (0 = EN, 1 = FR, 2 = IT, 3 = DE, 4 = ES, 5 = JP)");
+    ini->SetInteger("Game", "Language", Engine.language);
+    ini->SetComment("Game", "OGCtrlComment", "Sets the game's spindash style (-1 = let save file decide, 0 = S2, 1 = CD)");
+    ini->SetInteger("Game", "OriginalControls", controlMode);
 
-    ini.SetComment("Window", "FSComment", "Determines if the window will be fullscreen or not");
-    ini.SetBool("Window", "FullScreen", Engine.startFullScreen);
-    ini.SetComment("Window", "BLComment", "Determines if the window will be borderless or not");
-    ini.SetBool("Window", "Borderless", Engine.borderless);
-    ini.SetComment("Window", "VSComment", "Determines if VSync will be active or not");
-    ini.SetBool("Window", "VSync", Engine.vsync);
-    ini.SetComment("Window", "ESComment", "Determines if Enhanced Scaling will be active or not. Only affects non-multiple resolutions.");
-    ini.SetBool("Window", "EnhancedScaling", Engine.enhancedScaling);
-    ini.SetComment("Window", "WSComment", "How big the window will be");
-    ini.SetInteger("Window", "WindowScale", Engine.windowScale);
-    ini.SetComment("Window", "SWComment", "How wide the base screen will be in pixels");
-    ini.SetInteger("Window", "ScreenWidth", SCREEN_XSIZE);
-    ini.SetComment("Window", "RRComment", "Determines the target FPS");
-    ini.SetInteger("Window", "RefreshRate", Engine.refreshRate);
+    ini->SetComment("Window", "FSComment", "Determines if the window will be fullscreen or not");
+    ini->SetBool("Window", "FullScreen", Engine.startFullScreen);
+    ini->SetComment("Window", "BLComment", "Determines if the window will be borderless or not");
+    ini->SetBool("Window", "Borderless", Engine.borderless);
+    ini->SetComment("Window", "VSComment", "Determines if VSync will be active or not");
+    ini->SetBool("Window", "VSync", Engine.vsync);
+    ini->SetComment("Window", "ESComment", "Determines if Enhanced Scaling will be active or not. Only affects non-multiple resolutions.");
+    ini->SetBool("Window", "EnhancedScaling", Engine.enhancedScaling);
+    ini->SetComment("Window", "WSComment", "How big the window will be");
+    ini->SetInteger("Window", "WindowScale", Engine.windowScale);
+    ini->SetComment("Window", "SWComment", "How wide the base screen will be in pixels");
+    ini->SetInteger("Window", "ScreenWidth", SCREEN_XSIZE);
+    ini->SetComment("Window", "RRComment", "Determines the target FPS");
+    ini->SetInteger("Window", "RefreshRate", Engine.refreshRate);
 
-    ini.SetFloat("Audio", "BGMVolume", bgmVolume / (float)MAX_VOLUME);
-    ini.SetFloat("Audio", "SFXVolume", sfxVolume / (float)MAX_VOLUME);
+    ini->SetFloat("Audio", "BGMVolume", bgmVolume / (float)MAX_VOLUME);
+    ini->SetFloat("Audio", "SFXVolume", sfxVolume / (float)MAX_VOLUME);
 
 #if RETRO_USING_SDL2
-    ini.SetComment("Keyboard 1", "IK1Comment", "Keyboard Mappings for P1 (Based on: https://wiki.libsdl.org/SDL_Scancode)");
+    ini->SetComment("Keyboard 1", "IK1Comment", "Keyboard Mappings for P1 (Based on: https://wiki.libsdl.org/SDL_Scancode)");
 #endif
 #if RETRO_USING_SDL1
-    ini.SetComment("Keyboard 1", "IK1Comment", "Keyboard Mappings for P1 (Based on: https://wiki.libsdl.org/SDLKeycodeLookup)");
+    ini->SetComment("Keyboard 1", "IK1Comment", "Keyboard Mappings for P1 (Based on: https://wiki.libsdl.org/SDLKeycodeLookup)");
 #endif
-    ini.SetComment("Keyboard 1", "IK1Comment", "Keyboard Mappings for P1 (Based on: https://wiki.libsdl.org/SDL_Scancode)");
-    ini.SetInteger("Keyboard 1", "Up", inputDevice[INPUT_UP].keyMappings);
-    ini.SetInteger("Keyboard 1", "Down", inputDevice[INPUT_DOWN].keyMappings);
-    ini.SetInteger("Keyboard 1", "Left", inputDevice[INPUT_LEFT].keyMappings);
-    ini.SetInteger("Keyboard 1", "Right", inputDevice[INPUT_RIGHT].keyMappings);
-    ini.SetInteger("Keyboard 1", "A", inputDevice[INPUT_BUTTONA].keyMappings);
-    ini.SetInteger("Keyboard 1", "B", inputDevice[INPUT_BUTTONB].keyMappings);
-    ini.SetInteger("Keyboard 1", "C", inputDevice[INPUT_BUTTONC].keyMappings);
-    ini.SetInteger("Keyboard 1", "Start", inputDevice[INPUT_START].keyMappings);
+    ini->SetComment("Keyboard 1", "IK1Comment", "Keyboard Mappings for P1 (Based on: https://wiki.libsdl.org/SDL_Scancode)");
+    ini->SetInteger("Keyboard 1", "Up", inputDevice[INPUT_UP].keyMappings);
+    ini->SetInteger("Keyboard 1", "Down", inputDevice[INPUT_DOWN].keyMappings);
+    ini->SetInteger("Keyboard 1", "Left", inputDevice[INPUT_LEFT].keyMappings);
+    ini->SetInteger("Keyboard 1", "Right", inputDevice[INPUT_RIGHT].keyMappings);
+    ini->SetInteger("Keyboard 1", "A", inputDevice[INPUT_BUTTONA].keyMappings);
+    ini->SetInteger("Keyboard 1", "B", inputDevice[INPUT_BUTTONB].keyMappings);
+    ini->SetInteger("Keyboard 1", "C", inputDevice[INPUT_BUTTONC].keyMappings);
+    ini->SetInteger("Keyboard 1", "Start", inputDevice[INPUT_START].keyMappings);
 
 #if RETRO_USING_SDL2
-    ini.SetComment("Controller 1", "IC1Comment", "Controller Mappings for P1 (Based on: https://wiki.libsdl.org/SDL_GameControllerButton)");
-    ini.SetComment("Controller 1", "IC1Comment2", "Extra buttons can be mapped with the following IDs:");
-    ini.SetComment("Controller 1", "IC1Comment3", "CONTROLLER_BUTTON_ZL             = 16");
-    ini.SetComment("Controller 1", "IC1Comment4", "CONTROLLER_BUTTON_ZR             = 17");
-    ini.SetComment("Controller 1", "IC1Comment5", "CONTROLLER_BUTTON_LSTICK_UP      = 18");
-    ini.SetComment("Controller 1", "IC1Comment6", "CONTROLLER_BUTTON_LSTICK_DOWN    = 19");
-    ini.SetComment("Controller 1", "IC1Comment7", "CONTROLLER_BUTTON_LSTICK_LEFT    = 20");
-    ini.SetComment("Controller 1", "IC1Comment8", "CONTROLLER_BUTTON_LSTICK_RIGHT   = 21");
-    ini.SetComment("Controller 1", "IC1Comment9", "CONTROLLER_BUTTON_RSTICK_UP      = 22");
-    ini.SetComment("Controller 1", "IC1Comment10", "CONTROLLER_BUTTON_RSTICK_DOWN    = 23");
-    ini.SetComment("Controller 1", "IC1Comment11", "CONTROLLER_BUTTON_RSTICK_LEFT    = 24");
-    ini.SetComment("Controller 1", "IC1Comment12", "CONTROLLER_BUTTON_RSTICK_RIGHT   = 25");
+    ini->SetComment("Controller 1", "IC1Comment", "Controller Mappings for P1 (Based on: https://wiki.libsdl.org/SDL_GameControllerButton)");
+    ini->SetComment("Controller 1", "IC1Comment2", "Extra buttons can be mapped with the following IDs:");
+    ini->SetComment("Controller 1", "IC1Comment3", "CONTROLLER_BUTTON_ZL             = 16");
+    ini->SetComment("Controller 1", "IC1Comment4", "CONTROLLER_BUTTON_ZR             = 17");
+    ini->SetComment("Controller 1", "IC1Comment5", "CONTROLLER_BUTTON_LSTICK_UP      = 18");
+    ini->SetComment("Controller 1", "IC1Comment6", "CONTROLLER_BUTTON_LSTICK_DOWN    = 19");
+    ini->SetComment("Controller 1", "IC1Comment7", "CONTROLLER_BUTTON_LSTICK_LEFT    = 20");
+    ini->SetComment("Controller 1", "IC1Comment8", "CONTROLLER_BUTTON_LSTICK_RIGHT   = 21");
+    ini->SetComment("Controller 1", "IC1Comment9", "CONTROLLER_BUTTON_RSTICK_UP      = 22");
+    ini->SetComment("Controller 1", "IC1Comment10", "CONTROLLER_BUTTON_RSTICK_DOWN    = 23");
+    ini->SetComment("Controller 1", "IC1Comment11", "CONTROLLER_BUTTON_RSTICK_LEFT    = 24");
+    ini->SetComment("Controller 1", "IC1Comment12", "CONTROLLER_BUTTON_RSTICK_RIGHT   = 25");
 #endif
-    ini.SetInteger("Controller 1", "Up", inputDevice[INPUT_UP].contMappings);
-    ini.SetInteger("Controller 1", "Down", inputDevice[INPUT_DOWN].contMappings);
-    ini.SetInteger("Controller 1", "Left", inputDevice[INPUT_LEFT].contMappings);
-    ini.SetInteger("Controller 1", "Right", inputDevice[INPUT_RIGHT].contMappings);
-    ini.SetInteger("Controller 1", "A", inputDevice[INPUT_BUTTONA].contMappings);
-    ini.SetInteger("Controller 1", "B", inputDevice[INPUT_BUTTONB].contMappings);
-    ini.SetInteger("Controller 1", "C", inputDevice[INPUT_BUTTONC].contMappings);
-    ini.SetInteger("Controller 1", "Start", inputDevice[INPUT_START].contMappings);
+    ini->SetInteger("Controller 1", "Up", inputDevice[INPUT_UP].contMappings);
+    ini->SetInteger("Controller 1", "Down", inputDevice[INPUT_DOWN].contMappings);
+    ini->SetInteger("Controller 1", "Left", inputDevice[INPUT_LEFT].contMappings);
+    ini->SetInteger("Controller 1", "Right", inputDevice[INPUT_RIGHT].contMappings);
+    ini->SetInteger("Controller 1", "A", inputDevice[INPUT_BUTTONA].contMappings);
+    ini->SetInteger("Controller 1", "B", inputDevice[INPUT_BUTTONB].contMappings);
+    ini->SetInteger("Controller 1", "C", inputDevice[INPUT_BUTTONC].contMappings);
+    ini->SetInteger("Controller 1", "Start", inputDevice[INPUT_START].contMappings);
 
-    ini.Write(BASE_PATH"settings.ini");
+    ini->Write(BASE_PATH"settings.ini");
+
+    delete ini;
 }
 
 void ReadUserdata()

--- a/dependencies/all/theoraplay/theoraplay.c
+++ b/dependencies/all/theoraplay/theoraplay.c
@@ -19,7 +19,14 @@
 #include <string.h>
 #include <assert.h>
 
-#ifdef _WIN32
+#include "../../../SonicCDDecomp/RetroEngine.hpp"
+
+#if RETRO_USING_SDL2
+#include "SDL.h"
+#define sleepms(x) SDL_Delay(x)
+#define THEORAPLAY_THREAD_T    SDL_Thread*
+#define THEORAPLAY_MUTEX_T     SDL_mutex*
+#elif defined(_WIN32)
 #include <windows.h>
 #define THEORAPLAY_THREAD_T    HANDLE
 #define THEORAPLAY_MUTEX_T     HANDLE
@@ -137,8 +144,36 @@ typedef struct TheoraDecoder
     AudioPacket *audiolisttail;
 } TheoraDecoder;
 
+#if RETRO_USING_SDL2
+static inline int Thread_Create(TheoraDecoder *ctx, void *(*routine) (void*))
+{
+    ctx->worker = SDL_CreateThread((int(*)(void*))routine, "", ctx);
 
-#ifdef _WIN32
+    return ctx->worker == NULL;
+}
+static inline void Thread_Join(THEORAPLAY_THREAD_T thread)
+{
+    SDL_WaitThread(thread, NULL);
+}
+static inline int Mutex_Create(TheoraDecoder *ctx)
+{
+    ctx->lock = SDL_CreateMutex();
+
+    return ctx->lock == NULL;
+}
+static inline void Mutex_Destroy(THEORAPLAY_MUTEX_T mutex)
+{
+    SDL_DestroyMutex(mutex);
+}
+static inline void Mutex_Lock(THEORAPLAY_MUTEX_T mutex)
+{
+    SDL_LockMutex(mutex);
+}
+static inline void Mutex_Unlock(THEORAPLAY_MUTEX_T mutex)
+{
+    SDL_UnlockMutex(mutex);
+}
+#elif defined(_WIN32)
 static inline int Thread_Create(TheoraDecoder *ctx, void *(*routine) (void*))
 {
     ctx->worker = CreateThread(
@@ -199,7 +234,6 @@ static inline void Mutex_Unlock(THEORAPLAY_MUTEX_T mutex)
     pthread_mutex_unlock(&mutex);
 }
 #endif
-
 
 static int FeedMoreOggData(THEORAPLAY_Io *io, ogg_sync_state *sync)
 {

--- a/dependencies/wii-u/ppc-libtheora/PKGBUILD
+++ b/dependencies/wii-u/ppc-libtheora/PKGBUILD
@@ -1,0 +1,44 @@
+pkgname=ppc-libtheora
+pkgver=1.1.1
+pkgrel=2
+pkgdesc='Free and open video compression codec from the Xiph.org Foundation'
+arch=('any')
+url='https://www.theora.org/'
+license=(Xiph.org)
+options=(!strip libtool staticlibs)
+source=("http://downloads.xiph.org/releases/theora/libtheora-${pkgver}.tar.bz2" "config.sub" "config.guess")
+sha256sums=(
+ 'b6ae1ee2fa3d42ac489287d3ec34c5885730b1296f0801ae577a35193d3affbc'
+ '72e02ea93447038f8ced24f296b31e0f397bbcc6b32abdcf9b38c80f153433fd'
+ 'fbc2337aa59a204f5d74743b82c8be7aab8b39853b4e54a888008f70430c4305'
+)
+
+makedepends=('ppc-pkg-config' 'devkitpro-pkgbuild-helpers')
+depends=('ppc-libogg' 'ppc-libvorbis' 'ppc-libpng')
+groups=('ppc-portlibs')
+build() {
+  cd libtheora-$pkgver
+
+  source /opt/devkitpro/ppcvars.sh
+
+  cp $srcdir/config.sub $srcdir/config.guess .
+
+  ./configure --prefix="${PORTLIBS_PREFIX}" --host=powerpc-eabi \
+    --disable-shared --enable-static \
+    --disable-encode --disable-examples
+
+  make
+}
+
+package() {
+  cd libtheora-$pkgver
+
+  source /opt/devkitpro/ppcvars.sh
+
+  make DESTDIR="$pkgdir" install
+
+  install -Dm644 COPYING "$pkgdir"${PORTLIBS_PREFIX}/licenses/$pkgname/COPYING
+
+  # remove useless documentation
+  rm -r "$pkgdir"${PORTLIBS_PREFIX}/share/doc
+}


### PR DESCRIPTION
This is a plain Wii U port. The port itself was simple enough - it just required some extensions to `RetroEngine.hpp` and `Makefile`, and some initialisation/deinitialisation in `RetroEngine.cpp`. The real buik came from the `Reader.cpp` overhaul:

The previous `Reader.cpp` wasn't thread-safe, and yet it was used on both the main thread and the audio thread, likely leading to the issue described [in this issue](https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation/issues/125). This same problem affected my Wii U port, with the audio suffering a massive delay (or the whole game just crashing) when changing songs.

I've addressed this by moving a bunch of global state into a struct, allowing the caller to allocate its own struct so that its use of the reader doesn't conflict with any concurrent usage. Unfortunately, this modification is extremely invasive, requiring edits throughout the codebase. The API's use of default parameters is partly for backwards-compatibility, but I find it pretty ugly and unintuitive. It might be best to change this at some point and make the struct selection explicit, or maybe even have the `LoadFile`  function allocate and return its own struct just like `fopen`.

I've also improved TheoraPlay's portability by having it make use of SDL2's threading API when available, instead of Win32 or POSIX.

Some `IniParser` objects were moved off the stack, as they were causing stack overflows on the Wii U.

Finally, the music initialisation logic should now properly handle errors.