### PR TITLE
Add Linux hardware rendering

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,4 +193,21 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: SonicCD-Linux
-          path: bin/soniccd
+          path: bin
+  
+  linux_HW:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libtheora-dev libogg-dev libvorbis-dev libsdl2-dev libglew-dev
+      - name: Build Sonic CD
+        run: make USE_HW_REN=1
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: SonicCD-Linux_HW
+          path: bin

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,11 @@ ifeq ($(FORCE_CASE_INSENSITIVE),1)
   SOURCES += SonicCDDecomp/fcaseopen.c
 endif
 
+ifeq ($(USE_HW_REN),1)
+  CXXFLAGS_ALL += -DUSE_HW_REN
+  LIBS_ALL += -lGL -lGLEW
+endif
+
 OBJECTS = $(SOURCES:%=objects/%.o)
 DEPENDENCIES = $(SOURCES:%=objects/%.d)
 


### PR DESCRIPTION
To build, just type `make USE_HW_REN=1`.
Requires libGL and libGLEW development packages (`libglew-dev` on Ubuntu, `glew` on Arch)