### PR TITLE
WIP: Added support for building with CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Debian Buster is still stuck on CMake 3.13, so let's target that.
+cmake_minimum_required(VERSION 3.13)
+
+project(
+	RSDKv3
+	DESCRIPTION "A full decompilation of RSDKv3 & Sonic CD 2011."
+	VERSION 1.1.0
+	LANGUAGES C CXX
+)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
+
+add_subdirectory("RSDKv3")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,4 @@ project(
 	LANGUAGES C CXX
 )
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
-
 add_subdirectory("RSDKv3")

--- a/RSDKv3/CMakeLists.txt
+++ b/RSDKv3/CMakeLists.txt
@@ -1,0 +1,62 @@
+# pkg-config is inconvenient on Windows, perhaps we could use vcpkg there?
+find_package(PkgConfig REQUIRED)
+find_package(Threads REQUIRED)
+
+pkg_search_module(SDL2 REQUIRED sdl2)
+pkg_search_module(VORBIS REQUIRED vorbis)
+pkg_search_module(VORBISFILE REQUIRED vorbisfile)
+pkg_search_module(THEORADEC REQUIRED theoradec)
+
+set(DEPENDENCIES_DIR "${CMAKE_SOURCE_DIR}/dependencies")
+set(THEORAPLAY_DIR "${DEPENDENCIES_DIR}/all/theoraplay")
+set(GHC_FILESYSTEM_DIR "${DEPENDENCIES_DIR}/all/filesystem")
+
+add_library(
+	theoraplay
+	STATIC
+	"${THEORAPLAY_DIR}/theoraplay_cvtrgb.h"
+	"${THEORAPLAY_DIR}/theoraplay.h"
+	"${THEORAPLAY_DIR}/theoraplay.c"
+)
+target_include_directories(theoraplay PUBLIC "${THEORAPLAY_DIR}")
+target_link_libraries(theoraplay PRIVATE Threads::Threads)
+target_link_libraries(theoraplay PRIVATE ${VORBIS_LIBRARIES})
+target_link_libraries(theoraplay PRIVATE ${THEORADEC_LIBRARIES})
+
+add_subdirectory(
+	"${GHC_FILESYSTEM_DIR}"
+	"${GHC_FILESYSTEM_DIR}/build"
+)
+
+add_executable(
+	soniccd
+	Animation.hpp Animation.cpp
+	Audio.hpp Audio.cpp
+	Collision.hpp Collision.cpp
+	Debug.hpp Debug.cpp
+	Drawing.hpp Drawing.cpp
+	fcaseopen.h fcaseopen.c
+	Ini.hpp Ini.cpp
+	Input.hpp Input.cpp
+	main.cpp
+	Math.hpp Math.cpp
+	Object.hpp Object.cpp
+	Palette.hpp Palette.cpp
+	Player.hpp Player.cpp
+	Reader.hpp Reader.cpp
+	resource.h
+	RetroEngine.hpp RetroEngine.cpp
+	Scene3D.hpp Scene3D.cpp
+	Scene.hpp Scene.cpp
+	Script.hpp Script.cpp
+	Sprite.hpp Sprite.cpp
+	String.hpp String.cpp
+	Text.hpp Text.cpp
+	Userdata.hpp Userdata.cpp
+	Video.hpp Video.cpp
+)
+target_include_directories(soniccd PRIVATE ${SDL2_INCLUDE_DIRS})
+target_link_libraries(soniccd PRIVATE ${SDL2_LIBRARIES})
+target_link_libraries(soniccd PRIVATE theoraplay)
+target_link_libraries(soniccd PRIVATE ghc_filesystem)
+target_link_libraries(soniccd PRIVATE ${VORBISFILE_LIBRARIES})


### PR DESCRIPTION
I've added CMakeLists.txt files to the project root and the RSDKv3 folder, enabling compilation through CMake.

I've also marked this as a work-in-progress so it can be reviewed before merging, if accepted, to avoid mistakes going into upstream.

I have only tested it on Arch Linux, using pkg-config to locate the dependencies (same as the existing makefile). The game seems to run just fine, no problems whatsoever.

For Windows it _could_ be possible to use vcpkg or manually create FindXXX CMake modules, but I haven't looked much into it.

I saw there's an "upng" dependency now, but AFAIK it doesn't impede compilation? I haven't added it to the build yet because I don't understand how it's used, maybe it's specific to the ports, so maybe it could be referenced depending on build flags/platform detection.