### PR TITLE
Remove redundant glu.h inclusion: glew manages this.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,14 @@ ifeq ($(STATIC),1)
   CXXFLAGS_ALL += -static
 endif
 
-CXXFLAGS_ALL += -MMD -MP -MF objects/$*.d $(shell pkg-config --cflags $(PKG_CONFIG_STATIC_FLAG) vorbisfile vorbis theoradec sdl2 glew) $(CXXFLAGS) \
+CXXFLAGS_ALL += -MMD -MP -MF objects/$*.d $(shell pkg-config --cflags $(PKG_CONFIG_STATIC_FLAG) vorbisfile vorbis theoradec sdl2 glew tinyxml2) $(CXXFLAGS) \
    -Idependencies/all/filesystem/include \
    -Idependencies/all/theoraplay \
    -Idependencies/all/tinyxml2/
 LDFLAGS_ALL += $(LDFLAGS)
-LIBS_ALL += $(shell pkg-config --libs $(PKG_CONFIG_STATIC_FLAG) vorbisfile vorbis theoradec sdl2 glew) -pthread $(LIBS)
+LIBS_ALL += $(shell pkg-config --libs $(PKG_CONFIG_STATIC_FLAG) vorbisfile vorbis theoradec sdl2 glew tinyxml2) -pthread $(LIBS)
 
 SOURCES = \
-  dependencies/all/tinyxml2/tinyxml2.cpp \
   dependencies/all/theoraplay/theoraplay.c \
   RSDKv3/Animation.cpp \
   RSDKv3/Audio.cpp \

--- a/RSDKv3/RetroEngine.hpp
+++ b/RSDKv3/RetroEngine.hpp
@@ -163,7 +163,6 @@ typedef unsigned int uint;
 #define GL_FRAMEBUFFER_BINDING GL_FRAMEBUFFER_BINDING_EXT
 #else
 #include <GL/glew.h>
-#include <GL/glu.h>
 #endif
 #endif
 


### PR DESCRIPTION
By including glew.h, glu.h is included (if needed by glew).
This inclusion is redundant and breaks building on any modern systems where glew is present but old glu is not.