### PR TITLE
Added instruction for Fedora Linux users

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Even if your platform isn't supported by the official releases, you **must** buy
 ## Linux
 * To setup your build enviroment and library dependecies run the following commands:
   * Ubuntu (Mint, Pop!\_OS, etc...): `sudo apt install build-essential git libsdl2-dev libvorbis-dev libogg-dev libtheora-dev libglew-dev`
+  * Fedora Linux: `sudo rpm install g++ SDL2-devel libvorbis-devel libogg-devel libtheora-devel glew-devel tinyxml2-devel`
   * Arch Linux: `sudo pacman -S base-devel git sdl2 libvorbis libogg libtheora libglew`
 * Clone the repo with the following command: `git clone https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation.git`.
 * Go into the repo you just cloned with `cd Sonic-CD-11-Decompilation`.


### PR DESCRIPTION
according to my own observation it seems like the git clone https://github.com/leethomason/tinyxml2.git ./dependencies/all/tinyxml2 is not necessary with linux distros, but i haven't tested on any besides fedora to prove that