### PR TITLE
Fix flatpak builds and some other Linux fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ ifeq ($(STATIC),1)
 endif
 
 CXXFLAGS_ALL += -MMD -MP -MF objects/$*.d $(shell pkg-config --cflags $(PKG_CONFIG_STATIC_FLAG) vorbisfile vorbis theoradec sdl2 glew) $(CXXFLAGS) \
+   -DBASE_PATH='"$(BASE_PATH)"' \
    -Idependencies/all/filesystem/include \
    -Idependencies/all/theoraplay \
    -Idependencies/all/tinyxml2/
@@ -60,7 +61,6 @@ bin/RSDKv3: $(OBJECTS)
 
 install: bin/RSDKv3
 	install -Dp -m755 bin/RSDKv3 $(prefix)/bin/RSDKv3
-	chmod -x $(prefix)/bin/RSDKv3
 
 clean:
 	 rm -r -f bin && rm -r -f objects

--- a/RSDKv3/RetroEngine.hpp
+++ b/RSDKv3/RetroEngine.hpp
@@ -36,6 +36,7 @@ typedef unsigned int uint;
 // Custom Platforms start here
 #define RETRO_VITA (7)
 #define RETRO_UWP  (8)
+#define RETRO_LINUX (9)
 
 // Platform types (Game manages platform-specific code such as HUD position using this rather than the above)
 #define RETRO_STANDARD (0)
@@ -70,6 +71,8 @@ typedef unsigned int uint;
 #define RETRO_PLATFORM (RETRO_ANDROID)
 #elif defined __vita__
 #define RETRO_PLATFORM (RETRO_VITA)
+#elif defined __linux__
+#define RETRO_PLATFORM (RETRO_LINUX)
 #else
 #define RETRO_PLATFORM (RETRO_WIN) // Default
 #endif
@@ -93,7 +96,7 @@ typedef unsigned int uint;
 #endif
 
 #if RETRO_PLATFORM == RETRO_WIN || RETRO_PLATFORM == RETRO_OSX || RETRO_PLATFORM == RETRO_iOS || RETRO_PLATFORM == RETRO_VITA                        \
-    || RETRO_PLATFORM == RETRO_UWP || RETRO_PLATFORM == RETRO_ANDROID
+    || RETRO_PLATFORM == RETRO_UWP || RETRO_PLATFORM == RETRO_ANDROID || RETRO_PLATFORM == RETRO_LINUX
 #define RETRO_USING_SDL1 (0)
 #define RETRO_USING_SDL2 (1)
 #else // Since its an else & not an elif these platforms probably aren't supported yet
@@ -175,6 +178,8 @@ typedef unsigned int uint;
 #define RETRO_GAMEPLATFORMID (RETRO_WIN)
 #elif RETRO_PLATFORM == RETRO_UWP
 #define RETRO_GAMEPLATFORMID (UAP_GetRetroGamePlatformId())
+#elif RETRO_PLATFORM == RETRO_LINUX
+#define RETRO_GAMEPLATFORMID (RETRO_STANDARD)
 #else
 #error Unspecified RETRO_GAMEPLATFORMID
 #endif
@@ -270,7 +275,7 @@ enum RetroBytecodeFormat {
 #define SCREEN_YSIZE   (240)
 #define SCREEN_CENTERY (SCREEN_YSIZE / 2)
 
-#if RETRO_PLATFORM == RETRO_WIN || RETRO_PLATFORM == RETRO_UWP || RETRO_PLATFORM == RETRO_ANDROID
+#if RETRO_PLATFORM == RETRO_WIN || RETRO_PLATFORM == RETRO_UWP || RETRO_PLATFORM == RETRO_ANDROID || RETRO_PLATFORM == RETRO_LINUX
 #if RETRO_USING_SDL2
 #include <SDL.h>
 #elif RETRO_USING_SDL1

--- a/RSDKv3/RetroEngine.hpp
+++ b/RSDKv3/RetroEngine.hpp
@@ -83,7 +83,9 @@ typedef unsigned int uint;
 #define DEFAULT_SCREEN_XSIZE 424
 #define DEFAULT_FULLSCREEN   false
 #else
-#define BASE_PATH ""
+#ifndef BASE_PATH
+#define BASE_PATH            ""
+#endif
 #define RETRO_USING_MOUSE
 #define RETRO_USING_TOUCH
 #define DEFAULT_SCREEN_XSIZE 424

--- a/RSDKv3/Userdata.cpp
+++ b/RSDKv3/Userdata.cpp
@@ -60,7 +60,7 @@ int saveRAM[SAVEDATA_SIZE];
 Achievement achievements[ACHIEVEMENT_COUNT];
 LeaderboardEntry leaderboards[LEADERBOARD_COUNT];
 
-#if RETRO_PLATFORM == RETRO_OSX
+#if RETRO_PLATFORM == RETRO_OSX || RETRO_PLATFORM == RETRO_LINUX
 #include <sys/stat.h>
 #include <sys/types.h>
 #endif
@@ -77,6 +77,24 @@ bool forceUseScripts_Config = false;
 
 bool useSGame = false;
 
+#if RETRO_PLATFORM == RETRO_LINUX
+std::string getXDGDataPath() 
+{
+    std::string path;
+    char const *dataHome = getenv("XDG_DATA_HOME");
+    if (dataHome == NULL) {
+        char const *home = getenv("HOME");
+        path += home;
+        path += "/.local/share/";
+    }
+    else {
+        path += dataHome;
+    }
+    path += "/RSDKv3";
+    return path;
+}
+#endif
+
 bool ReadSaveRAMData()
 {
     useSGame = false;
@@ -92,6 +110,8 @@ bool ReadSaveRAMData()
     sprintf(buffer, "%s/%sSData.bin", redirectSave ? modsPath : gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
     sprintf(buffer, "%s/%sSData.bin", redirectSave ? modsPath : getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+    sprintf(buffer, "%s/%sSData.bin", redirectSave ? modsPath : getXDGDataPath().c_str(), savePath);
 #else
     sprintf(buffer, "%s%sSData.bin", redirectSave ? modsPath : gamePath, savePath);
 #endif
@@ -105,6 +125,8 @@ bool ReadSaveRAMData()
     sprintf(buffer, "%s/%sSData.bin", gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
     sprintf(buffer, "%s/%sSData.bin", getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+    sprintf(buffer, "%s/%sSData.bin", getXDGDataPath().c_str(), savePath);
 #else
     sprintf(buffer, "%s%sSData.bin", gamePath, savePath);
 #endif
@@ -133,6 +155,8 @@ bool ReadSaveRAMData()
         sprintf(buffer, "%s/%sSGame.bin", redirectSave ? modsPath : gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
         sprintf(buffer, "%s/%sSGame.bin", redirectSave ? modsPath : getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+        sprintf(buffer, "%s/%sSGame.bin", redirectSave ? modsPath : getXDGDataPath().c_str(), savePath);
 #else
         sprintf(buffer, "%s%sSGame.bin", redirectSave ? modsPath : gamePath, savePath);
 #endif
@@ -146,6 +170,8 @@ bool ReadSaveRAMData()
         sprintf(buffer, "%s/%sSGame.bin", gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
         sprintf(buffer, "%s/%sSGame.bin", getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+        sprintf(buffer, "%s/%sSGame.bin", getXDGDataPath().c_str(), savePath);
 #else
         sprintf(buffer, "%s%sSGame.bin", gamePath, savePath);
 #endif
@@ -176,6 +202,8 @@ bool WriteSaveRAMData()
         sprintf(buffer, "%s/%sSData.bin", redirectSave ? modsPath : gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
         sprintf(buffer, "%s/%sSData.bin", redirectSave ? modsPath : getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+        sprintf(buffer, "%s/%sSData.bin", redirectSave ? modsPath : getXDGDataPath().c_str(), savePath);
 #else
         sprintf(buffer, "%s%sSData.bin", redirectSave ? modsPath : gamePath, savePath);
 #endif
@@ -189,6 +217,8 @@ bool WriteSaveRAMData()
         sprintf(buffer, "%s/%sSData.bin", gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
         sprintf(buffer, "%s/%sSData.bin", getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+        sprintf(buffer, "%s/%sSData.bin", getXDGDataPath().c_str(), savePath);
 #else
         sprintf(buffer, "%s%sSData.bin", gamePath, savePath);
 #endif
@@ -205,6 +235,8 @@ bool WriteSaveRAMData()
         sprintf(buffer, "%s/%sSGame.bin", redirectSave ? modsPath : gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
         sprintf(buffer, "%s/%sSGame.bin", redirectSave ? modsPath : getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+        sprintf(buffer, "%s/%sSGame.bin", redirectSave ? modsPath : getXDGDataPath().c_str(), savePath);
 #else
         sprintf(buffer, "%s%sSGame.bin", redirectSave ? modsPath : gamePath, savePath);
 #endif
@@ -218,6 +250,8 @@ bool WriteSaveRAMData()
         sprintf(buffer, "%s/%sSGame.bin", gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
         sprintf(buffer, "%s/%sSGame.bin", getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+        sprintf(buffer, "%s/%sSGame.bin", getXDGDataPath().c_str(), savePath);
 #else
         sprintf(buffer, "%s%sSGame.bin", gamePath, savePath);
 #endif
@@ -257,6 +291,11 @@ void InitUserdata()
     sprintf(modsPath, "%s/RSDKv3/", getResourcesPath());
 
     mkdir(gamePath, 0777);
+#elif RETRO_PLATFORM == RETRO_LINUX
+    sprintf(gamePath, "%s", getXDGDataPath().c_str());
+    sprintf(modsPath, "%s", getXDGDataPath().c_str());
+
+    mkdir(getXDGDataPath().c_str(), 0755);
 #elif RETRO_PLATFORM == RETRO_ANDROID
     {
         char buffer[0x200];
@@ -289,6 +328,8 @@ void InitUserdata()
     sprintf(buffer, "%s/settings.ini", gamePath);
 #elif RETRO_PLATFORM == RETRO_iOS
     sprintf(buffer, "%s/settings.ini", getDocumentsPath());
+#elif RETRO_PLATFORM == RETRO_LINUX
+    sprintf(buffer, "%s/settings.ini", getXDGDataPath().c_str());
 #else
     sprintf(buffer, BASE_PATH "settings.ini");
 #endif
@@ -673,6 +714,8 @@ void InitUserdata()
     sprintf(buffer, "%s/UData.bin", gamePath);
 #elif RETRO_PLATFORM == RETRO_iOS
     sprintf(buffer, "%s/UData.bin", getDocumentsPath());
+#elif RETRO_PLATFORM == RETRO_LINUX
+    sprintf(buffer, "%s/UData.bin", getXDGDataPath().c_str());
 #else
     sprintf(buffer, "%sUdata.bin", gamePath);
 #endif
@@ -820,6 +863,8 @@ void WriteSettings()
     sprintf(buffer, "%s/settings.ini", gamePath);
 #elif RETRO_PLATFORM == RETRO_iOS
     sprintf(buffer, "%s/settings.ini", getDocumentsPath());
+#elif RETRO_PLATFORM == RETRO_LINUX
+    sprintf(buffer, "%s/settings.ini", getXDGDataPath().c_str());
 #else
     sprintf(buffer, BASE_PATH "settings.ini");
 #endif
@@ -840,6 +885,8 @@ void ReadUserdata()
     sprintf(buffer, "%s/%sUData.bin", redirectSave ? modsPath : gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
     sprintf(buffer, "%s/%sUData.bin", redirectSave ? modsPath : getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+    sprintf(buffer, "%s/%sUData.bin", redirectSave ? modsPath : getXDGDataPath().c_str(), savePath);
 #else
     sprintf(buffer, "%s%sUData.bin", redirectSave ? modsPath : gamePath, savePath);
 #endif
@@ -853,6 +900,8 @@ void ReadUserdata()
     sprintf(buffer, "%s/%sUData.bin", gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
     sprintf(buffer, "%s/%sUData.bin", getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+    sprintf(buffer, "%s/%sUData.bin", getXDGDataPath().c_str(), savePath);
 #else
     sprintf(buffer, "%s%sUData.bin", gamePath, savePath);
 #endif
@@ -894,6 +943,8 @@ void WriteUserdata()
     sprintf(buffer, "%s/%sUData.bin", redirectSave ? modsPath : gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
     sprintf(buffer, "%s/%sUData.bin", redirectSave ? modsPath : getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+    sprintf(buffer, "%s/%sUData.bin", redirectSave ? modsPath : getXDGDataPath().c_str(), savePath);
 #else
     sprintf(buffer, "%s%sUData.bin", redirectSave ? modsPath : gamePath, savePath);
 #endif
@@ -907,6 +958,8 @@ void WriteUserdata()
     sprintf(buffer, "%s/%sUData.bin", gamePath, savePath);
 #elif RETRO_PLATFORM == RETRO_iOS
     sprintf(buffer, "%s/%sUData.bin", getDocumentsPath(), savePath);
+#elif RETRO_PLATFORM == RETRO_LINUX
+    sprintf(buffer, "%s/%sUData.bin", getXDGDataPath().c_str(), savePath);
 #else
     sprintf(buffer, "%s%sUData.bin", gamePath, savePath);
 #endif

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -9,23 +9,36 @@ First, go to your Steam library, right click on Sonic CD and click `Manage` > `B
 Copy the `Data.rsdk` file and the `videos` folder into this directory.
 
 To build and install the flatpak, run:
+
+**System-wide:**
 ```
 $ sudo flatpak-builder --install --force-clean soniccd com.sega.SonicCDSteam.json
 ```
+**User:**
+```
+$ flatpak-builder --user --install --force-clean soniccd com.sega.SonicCDSteam.json
+```
 
 # Sonic CD (Android Version) Flatpak
+
+**This method will not install the video files, as the decompilation
+only supports video files from the Steam version.**
 
 First, you need to install the game on an Android device.
 To get it, visit https://www.sega.com/games/sonic-cd.
 
 Once you have the game, use a file manager on your device to navigate
 to the directory `Android/obb/com.sega.soniccd.classic` and copy the
-`patch.[number].com.sega.soniccd.classic.obb` file into this directory.
+`patch.[number].com.sega.soniccd.classic.obb` file into this directory as `Data.rsdk`.
 
 To build and install the flatpak, run:
+
+**System-wide:**
 ```
 $ sudo flatpak-builder --install --force-clean soniccd com.sega.SonicCDAndroid.json
 ```
+**User:**
+```
+$ flatpak-builder --user --install --force-clean soniccd com.sega.SonicCDAndroid.json
+```
 
-Note that using this method will not install the video files, as the decompilation
-only supports video files from the Steam version.

--- a/flatpak/com.sega.SonicCDAndroid.json
+++ b/flatpak/com.sega.SonicCDAndroid.json
@@ -26,7 +26,7 @@
                 "BASE_PATH=/app/share/soniccd/"
             ],
             "post-install": [
-                "cp patch*.obb /app/share/soniccd/Data.rsdk",
+                "install -Dp -m 644 Data.rsdk /app/share/soniccd/Data.rsdk",
                 "install -Dp -m 644 com.sega.SonicCD.desktop /app/share/applications/com.sega.SonicCD.desktop",
                 "install -Dp -m 644 com.sega.SonicCD.svg /app/share/icons/hicolor/256x256/apps/com.sega.SonicCD.svg",
                 "install -Dp -m 644 com.sega.SonicCD.appdata.xml /app/share/appdata/com.sega.SonicCD.appdata.xml"
@@ -36,6 +36,10 @@
                     "type": "git",
                     "url": "https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation.git",
                     "branch": "master"
+                },
+                {
+                    "type": "file",
+                    "path": "Data.rsdk"
                 },
                 {
                     "type": "file",

--- a/flatpak/com.sega.SonicCDSteam.json
+++ b/flatpak/com.sega.SonicCDSteam.json
@@ -27,7 +27,10 @@
             ],
             "post-install": [
                 "install -Dp -m 644 Data.rsdk /app/share/soniccd/Data.rsdk",
-                "cp -r ./videos /app/share/soniccd/videos",
+                "install -Dp -m 644 Bad_Ending.ogv /app/share/soniccd/videos/Bad_Ending.ogv",
+                "install -Dp -m 644 Good_Ending.ogv /app/share/soniccd/videos/Good_Ending.ogv",
+                "install -Dp -m 644 Opening.ogv /app/share/soniccd/videos/Opening.ogv",
+                "install -Dp -m 644 Pencil_Test.ogv /app/share/soniccd/videos/Pencil_Test.ogv",
                 "install -Dp -m 644 com.sega.SonicCD.desktop /app/share/applications/com.sega.SonicCD.desktop",
                 "install -Dp -m 644 com.sega.SonicCD.svg /app/share/icons/hicolor/256x256/apps/com.sega.SonicCD.svg",
                 "install -Dp -m 644 com.sega.SonicCD.appdata.xml /app/share/appdata/com.sega.SonicCD.appdata.xml"
@@ -41,6 +44,10 @@
                 {
                     "type": "file",
                     "path": "Data.rsdk"
+                },
+                {
+                    "type": "dir",
+                    "path": "videos"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
This pull request brings in a few fixes for Linux users. They are mostly related to making flatpaks work, but they are bringing in a proper RETRO_PLATFORM for Linux and XDG support.

The changes consist of the following:

- Read BASE_PATH from Make. [Backported from Sonic 1-2-2013](https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation/commit/cdd5ed49557a8632a15bc028275fcde00eaab098), originally done by Adrien Plazas (Kekun).
  - And remove "chmod -x" from it, otherwise the final build will complain about executable bit. 
- Define a RETRO_PLATFORM for Linux + XDG support. [Backported from Sonic 1-2-2013](https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation/pull/283), originally done by Santiago Cézar (santiagocezar).
- Fix build recipes files for Steam and Android flatpaks. Fixes issue #166 and any other possible issue with flatpaks.

The first two are the most important ones, the former actually makes the flatpak work (after fixing the recipes) and the latter fixes saving under flatpak, while standardizing saves under Linux.
I've tested them out and everything seems to be working out OK. I don't believe this will bring in a regression for any other platform, but I haven't tested them. 
If needed, I can revert the "chmod -x" change and manually re-add the execute bit in the flatpak build process itself, but I don't see why it was there in the first place.

For testing, you just need to change the `"url": "https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation.git",` to `"path": ".."` in the .json files under `flatpak/` or change the URL to my repo.