### PR TITLE
Fix garbage graphics on SDL2 when not in Fullscreen mode

### DIFF
--- a/RSDKv3/Drawing.cpp
+++ b/RSDKv3/Drawing.cpp
@@ -357,6 +357,8 @@ int InitRenderDevice()
     }
     SetScreenDimensions(SCREEN_XSIZE, SCREEN_YSIZE, vw, vh);
 #endif
+#elif RETRO_USING_SDL2
+    SetScreenDimensions(SCREEN_XSIZE, SCREEN_YSIZE, SCREEN_XSIZE * Engine.windowScale, SCREEN_YSIZE * Engine.windowScale);
 #endif
 
     if (Engine.startFullScreen) {


### PR DESCRIPTION
SetScreenDimensions/SetScreenSize wasn't called anymore after #207.