### PR TITLE
Use SDL_UpdateTexture instead of do the copy manually

### DIFF
--- a/RSDKv3/Drawing.cpp
+++ b/RSDKv3/Drawing.cpp
@@ -516,16 +516,7 @@ void FlipScreen()
         ushort *pixels = NULL;
         if (Engine.gameMode != ENGINE_VIDEOWAIT) {
             if (!drawStageGFXHQ) {
-                SDL_LockTexture(Engine.screenBuffer, NULL, (void **)&pixels, &pitch);
-                ushort *frameBufferPtr = Engine.frameBuffer;
-                for (int y = 0; y < SCREEN_YSIZE; ++y) {
-                    memcpy(pixels, frameBufferPtr, SCREEN_XSIZE * sizeof(ushort));
-                    frameBufferPtr += GFX_LINESIZE;
-                    pixels += pitch / sizeof(ushort);
-                }
-                // memcpy(pixels, Engine.frameBuffer, pitch * SCREEN_YSIZE); //faster but produces issues with odd numbered screen sizes
-                SDL_UnlockTexture(Engine.screenBuffer);
-
+                SDL_UpdateTexture(Engine.screenBuffer, NULL, (void *)Engine.frameBuffer, GFX_LINESIZE * sizeof(ushort));
                 SDL_RenderCopy(Engine.renderer, Engine.screenBuffer, NULL, destScreenPos);
             }
             else {


### PR DESCRIPTION
## Description
Making use of the `SDL_UpdateTexture` for do the copy texture content properly.

Previously you were doing:
```c
memcpy(pixels, Engine.frameBuffer, pitch * SCREEN_YSIZE); //faster but produces issues with odd numbered screen sizes
```
However as the comment said, that it is faster, but was producing some errors with "odd numbered screen sizes", this is because some devices have some requirements when rendering textures, as for instance, texture must be 128 bits multiples (as `PSP` has).

Then, this is why you decided to use the `pitch` and start copying line by line.
```c
SDL_LockTexture(Engine.screenBuffer, NULL, (void **)&pixels, &pitch);
ushort *frameBufferPtr = Engine.frameBuffer;
for (int y = 0; y < SCREEN_YSIZE; ++y) {
    memcpy(pixels, frameBufferPtr, SCREEN_XSIZE * sizeof(ushort));
    frameBufferPtr += GFX_LINESIZE;
    pixels += pitch / sizeof(ushort);
}
```

With that implementation you are "safer" but slower, so the proper implementation would be something like:
```c
SDL_LockTexture(Engine.screenBuffer, NULL, (void **)&pixels, &pitch);
ushort *frameBufferPtr = Engine.frameBuffer;
if (pitch != GFX_LINESIZE * sizeof(ushort)) {
    for (int y = 0; y < SCREEN_YSIZE; ++y) {
        memcpy(pixels, frameBufferPtr, SCREEN_XSIZE * sizeof(ushort));
        frameBufferPtr += GFX_LINESIZE;
        pixels += pitch / sizeof(ushort);
    }
} else {
    memcpy(pixels, Engine.frameBuffer, pitch * SCREEN_YSIZE); //faster but produces issues with odd numbered screen sizes
}
SDL_UnlockTexture(Engine.screenBuffer);
```

In this way, just these devices where the texture resolution requires to have some additional pitch will use the slow way, and the rest will use the fast way.

So, all this piece of code is what actually the `SDL_UpdateTexture` function is doing:
```c
SDL_UpdateTexture(Engine.screenBuffer, NULL, (void *)Engine.frameBuffer, GFX_LINESIZE * sizeof(ushort));
```

Cheers!