### PR TITLE
Remove useless length variable

### DIFF
--- a/RSDKv3/Input.cpp
+++ b/RSDKv3/Input.cpp
@@ -354,8 +354,7 @@ void ControllerClose(byte controllerID)
 void ProcessInput()
 {
 #if RETRO_USING_SDL2
-    int length           = 0;
-    const byte *keyState = SDL_GetKeyboardState(&length);
+    const byte *keyState = SDL_GetKeyboardState(NULL);
 
     if (inputType == 0) {
         for (int i = 0; i < INPUT_ANY; i++) {


### PR DESCRIPTION
The `length` variable is not used anywhere within the `ProcessInput()` function, so we can just remove it and pass in `NULL` to `SDL_GetKeyboardState()`.