### PR TITLE
Fix Mac high-DPI scaling

### DIFF
--- a/RSDKv3/Drawing.cpp
+++ b/RSDKv3/Drawing.cpp
@@ -358,6 +358,10 @@ int InitRenderDevice()
         vh = mode.w;
     }
     SetScreenDimensions(SCREEN_XSIZE, SCREEN_YSIZE, vw, vh);
+#elif RETRO_USING_SDL2 && RETRO_USING_OPENGL
+    int drawableWidth, drawableHeight;
+    SDL_GL_GetDrawableSize(Engine.window, &drawableWidth, &drawableHeight);
+    SetScreenDimensions(SCREEN_XSIZE, SCREEN_YSIZE, drawableWidth, drawableHeight);
 #elif RETRO_USING_SDL2
     SetScreenDimensions(SCREEN_XSIZE, SCREEN_YSIZE, SCREEN_XSIZE * Engine.windowScale, SCREEN_YSIZE * Engine.windowScale);
 #endif


### PR DESCRIPTION
Fixes the scaling issue seen in [this post](https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation/issues/133#issuecomment-949746490) in #133 

The current behaviour assumes that scaling between window coordinates and drawable pixels are the same in highdpi mode; which isn't true on MacOS and causes the game to render only to the lower left quadrant of the screen on so-called "retina" machines.
This PR adds a case to set the viewport size to the window's actual drawable space as reported by SDL_GL_GetDrawableSize when using SDL2 & OpenGL, I left the non-GL SDL2 logic alone because SDL_RenderSetLogicalSize already handles this correctly.

Tested with both sw and hw modes.