### PR TITLE
Fix unspecified audio tracks crashing when played

### DIFF
--- a/RSDKv3/Audio.cpp
+++ b/RSDKv3/Audio.cpp
@@ -644,8 +644,10 @@ bool PlayMusic(int track)
         return false;
 
 #if !RETRO_USE_ORIGINAL_CODE
-	if (StrComp(musicTracks[track].fileName, "Data/Music/"))
-		return false;
+    if (StrComp(musicTracks[track].fileName, "Data/Music/")) {
+        StopMusic();
+        return false;
+    }
 #endif
 
     if (musicTracks[track].fileName[0]) {


### PR DESCRIPTION
Stops music tracks from playing if said track didn't get an audio file set
This fixes issues on some systems where it will crash the engine, whereas on Windows it runs fine